### PR TITLE
Add support for bareflank on kvm

### DIFF
--- a/include/intrinsics/cpuid_x64.h
+++ b/include/intrinsics/cpuid_x64.h
@@ -1053,6 +1053,151 @@ namespace cpuid
             }
         }
     }
+
+    namespace arch_perf_monitoring
+    {
+        constexpr const auto addr = 0x0000000AUL;
+        constexpr const auto name = "arch_perf_monitoring";
+
+        namespace eax
+        {
+            namespace version_id
+            {
+                constexpr const auto mask = 0x000000FFUL;
+                constexpr const auto from = 0UL;
+                constexpr const auto name = "version_id";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace gppmc_count
+            {
+                constexpr const auto mask = 0x0000FF00UL;
+                constexpr const auto from = 8UL;
+                constexpr const auto name = "gppmc_count";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace gppmc_bit_width
+            {
+                constexpr const auto mask = 0x00FF0000UL;
+                constexpr const auto from = 16UL;
+                constexpr const auto name = "gppmc_bit_width";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace ebx_enumeration_length
+            {
+                constexpr const auto mask = 0xFF000000UL;
+                constexpr const auto from = 24;
+                constexpr const auto name = "ebx_enumeration_length";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace core_cycle_event
+            {
+                constexpr const auto mask = 0x00000001UL;
+                constexpr const auto from = 0UL;
+                constexpr const auto name = "core_cycle_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace instr_retired_event
+            {
+                constexpr const auto mask = 0x00000002UL;
+                constexpr const auto from = 1UL;
+                constexpr const auto name = "instr_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace reference_cycles_event
+            {
+                constexpr const auto mask = 0x00000004UL;
+                constexpr const auto from = 2UL;
+                constexpr const auto name = "reference_cycles_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace llc_reference_event
+            {
+                constexpr const auto mask = 0x00000008UL;
+                constexpr const auto from = 3UL;
+                constexpr const auto name = "llc_reference_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace llc_misses_event
+            {
+                constexpr const auto mask = 0x00000010UL;
+                constexpr const auto from = 4UL;
+                constexpr const auto name = "llc_misses_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace branch_instr_retired_event
+            {
+                constexpr const auto mask = 0x00000020UL;
+                constexpr const auto from = 5UL;
+                constexpr const auto name = "branch_instr_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace branch_mispredict_retired_event
+            {
+                constexpr const auto mask = 0x00000040UL;
+                constexpr const auto from = 6UL;
+                constexpr const auto name = "branch_mispredict_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace ffpmc_count
+            {
+                constexpr const auto mask = 0x0000001FUL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "ffpmc_count";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace ffpmc_bit_width
+            {
+                constexpr const auto mask = 0x00001FE0UL;
+                constexpr const auto from = 5;
+                constexpr const auto name = "ffpmc_bit_width";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
 }
 }
 

--- a/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/src/vmcs/src/vmcs_intel_x64.cpp
@@ -284,7 +284,7 @@ vmcs_intel_x64::write_64bit_guest_state(gsl::not_null<vmcs_intel_x64_state *> st
     vmcs::guest_ia32_debugctl::set(state->ia32_debugctl_msr());
     vmcs::guest_ia32_pat::set(state->ia32_pat_msr());
     vmcs::guest_ia32_efer::set(state->ia32_efer_msr());
-    vmcs::guest_ia32_perf_global_ctrl::set(state->ia32_perf_global_ctrl_msr());
+    vmcs::guest_ia32_perf_global_ctrl::set_if_exists(state->ia32_perf_global_ctrl_msr());
 
     // unused: VMCS_GUEST_PDPTE0
     // unused: VMCS_GUEST_PDPTE1
@@ -371,7 +371,7 @@ vmcs_intel_x64::write_64bit_host_state(gsl::not_null<vmcs_intel_x64_state *> sta
 {
     vmcs::host_ia32_pat::set(state->ia32_pat_msr());
     vmcs::host_ia32_efer::set(state->ia32_efer_msr());
-    vmcs::host_ia32_perf_global_ctrl::set(state->ia32_perf_global_ctrl_msr());
+    vmcs::host_ia32_perf_global_ctrl::set_if_exists(state->ia32_perf_global_ctrl_msr());
 }
 
 void
@@ -476,9 +476,12 @@ vmcs_intel_x64::secondary_processor_based_vm_execution_controls()
 void
 vmcs_intel_x64::vm_exit_controls()
 {
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
+
     vm_exit_controls::save_debug_controls::enable();
     vm_exit_controls::host_address_space_size::enable();
-    vm_exit_controls::load_ia32_perf_global_ctrl::enable();
+    vm_exit_controls::load_ia32_perf_global_ctrl::enable_if_allowed(verbose);
+
     // vm_exit_controls::acknowledge_interrupt_on_exit::enable();
     vm_exit_controls::save_ia32_pat::enable();
     vm_exit_controls::load_ia32_pat::enable();
@@ -490,11 +493,14 @@ vmcs_intel_x64::vm_exit_controls()
 void
 vmcs_intel_x64::vm_entry_controls()
 {
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
+
     vm_entry_controls::load_debug_controls::enable();
     vm_entry_controls::ia_32e_mode_guest::enable();
     // vm_entry_controls::entry_to_smm::enable();
     // vm_entry_controls::deactivate_dual_monitor_treatment::enable();
-    vm_entry_controls::load_ia32_perf_global_ctrl::enable();
+    vm_entry_controls::load_ia32_perf_global_ctrl::enable_if_allowed(verbose);
+
     vm_entry_controls::load_ia32_pat::enable();
     vm_entry_controls::load_ia32_efer::enable();
 }

--- a/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
+++ b/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
@@ -23,9 +23,11 @@
 
 #include <intrinsics/msrs_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
+#include <intrinsics/cpuid_x64.h>
 
 using namespace x64;
 using namespace intel_x64;
+using namespace cpuid;
 
 vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state()
 {
@@ -57,7 +59,11 @@ vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state()
     m_ia32_debugctl_msr = intel_x64::msrs::ia32_debugctl::get();
     m_ia32_pat_msr = x64::msrs::ia32_pat::get();
     m_ia32_efer_msr = intel_x64::msrs::ia32_efer::get();
-    m_ia32_perf_global_ctrl_msr = intel_x64::msrs::ia32_perf_global_ctrl::get();
+
+    if (arch_perf_monitoring::eax::version_id::get() >= 2) {
+        m_ia32_perf_global_ctrl_msr = intel_x64::msrs::ia32_perf_global_ctrl::get();
+    }
+
     m_ia32_sysenter_cs_msr = intel_x64::msrs::ia32_sysenter_cs::get();
     m_ia32_sysenter_esp_msr = intel_x64::msrs::ia32_sysenter_esp::get();
     m_ia32_sysenter_eip_msr = intel_x64::msrs::ia32_sysenter_eip::get();

--- a/src/vmcs/src/vmcs_intel_x64_promote.asm
+++ b/src/vmcs/src/vmcs_intel_x64_promote.asm
@@ -22,6 +22,9 @@
 bits 64
 default rel
 
+%define CPUID_PERF_MONITORING                                     0x0000000A
+%define CPUID_PERF_MONITORING_VERSION_ID                          0x00000002
+
 %define VMCS_GUEST_IA32_DEBUGCTL_FULL                             0x00002802
 %define VMCS_GUEST_IA32_PAT_FULL                                  0x00002804
 %define VMCS_GUEST_IA32_EFER_FULL                                 0x00002806
@@ -81,11 +84,13 @@ extern _write_cr3;
 extern _write_cr4;
 extern _write_dr7;
 
+extern __cpuid_eax
+
 section .text
 
 ; Promote VMCS
 ;
-; Continues execution using the Guest state. Once this function execute,
+; Continues execution using the Guest state. Once this function executes,
 ; the host VMM will stop executing, and the guest will execute at the
 ; instruction that it exited on (likely the vmxoff instruction)
 ;
@@ -216,10 +221,22 @@ vmcs_promote:
     vmread rsi, rsi
     call _write_msr wrt ..plt
 
+    ;
+    ; Check CPUID.0AH:EAX[7:0] for the existence of
+    ; the IA32_PERF_GLOBAL_CTRL_MSR before writing
+    ;
+
+    mov edi, CPUID_PERF_MONITORING
+    call __cpuid_eax wrt ..plt
+    cmp al, CPUID_PERF_MONITORING_VERSION_ID
+    jl .perf_not_supported
+
     mov rdi, IA32_PERF_GLOBAL_CTRL_MSR
     mov rsi, VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
     vmread rsi, rsi
     call _write_msr wrt ..plt
+
+.perf_not_supported:
 
     mov rdi, IA32_SYSENTER_CS_MSR
     mov rsi, VMCS_GUEST_IA32_SYSENTER_CS

--- a/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/src/vmxon/src/vmxon_intel_x64.cpp
@@ -130,9 +130,12 @@ vmxon_intel_x64::check_ia32_vmx_cr4_fixed_msr()
 void
 vmxon_intel_x64::check_ia32_feature_control_msr()
 {
-    if (!intel_x64::msrs::ia32_feature_control::lock_bit::get()) {
-        throw std::logic_error("vmx lock bit == 0 is unsupported");
+    if (intel_x64::msrs::ia32_feature_control::lock_bit::get()) {
+        return;
     }
+
+    intel_x64::msrs::ia32_feature_control::enable_vmx_outside_smx::set(true);
+    intel_x64::msrs::ia32_feature_control::lock_bit::set(true);
 }
 
 void


### PR DESCRIPTION
There were two problems encountered when trying to run
Bareflank as a guest on KVM:

    1. KVM doesn't pass through access to the IA32_PERF_GLOBAL_CTRL
    msr (address 0x38F).

    2. KVM doesn't set the lock bit in the IA32_FEATURE_CONTROL msr
    (address 0x3A).

This commit is a minimal change to prevent unchecked accesses to
IA32_PERF_GLOBAL_CTRL and to allow for VMXON to succeed by setting
the enable_vmx_outside_smx bit (bit 2) and then the lock bit (bit 0)
in IA32_FEATURE_CONTROL.

Note that this patch was tested with Ubuntu 16.10 and Arch Linux
guest VMs running on an Ubuntu 16.10 KVM.