### PR TITLE
CPUID Functions and Tests

### DIFF
--- a/include/intrinsics/x86/common/cpuid/cpuid_x64.h
+++ b/include/intrinsics/x86/common/cpuid/cpuid_x64.h
@@ -24,6 +24,7 @@
 
 #include <bfdebug.h>
 #include <bfbitmanip.h>
+#include <iostream>
 
 // -----------------------------------------------------------------------------
 // Exports
@@ -102,12 +103,12 @@ namespace cpuid
 
     namespace addr_size
     {
-        constexpr const auto addr = 0x80000008U;
+        constexpr const auto addr = 0x80000008ULL;
         constexpr const auto name = "addr_size";
 
         namespace phys
         {
-            constexpr const auto mask = 0x000000FFU;
+            constexpr const auto mask = 0x000000FFULL;
             constexpr const auto from = 0;
             constexpr const auto name = "phys";
 
@@ -117,7 +118,7 @@ namespace cpuid
 
         namespace linear
         {
-            constexpr const auto mask = 0x0000FF00U;
+            constexpr const auto mask = 0x0000FF00ULL;
             constexpr const auto from = 8;
             constexpr const auto name = "linear";
 
@@ -128,14 +129,14 @@ namespace cpuid
 
     namespace feature_information
     {
-        constexpr const auto addr = 0x00000001U;
+        constexpr const auto addr = 0x00000001ULL;
         constexpr const auto name = "feature_information";
 
         namespace ecx
         {
             namespace sse3
             {
-                constexpr const auto mask = 0x00000001U;
+                constexpr const auto mask = 0x00000001ULL;
                 constexpr const auto from = 0;
                 constexpr const auto name = "sse3";
 
@@ -145,7 +146,7 @@ namespace cpuid
 
             namespace pclmulqdq
             {
-                constexpr const auto mask = 0x00000002U;
+                constexpr const auto mask = 0x00000002ULL;
                 constexpr const auto from = 1;
                 constexpr const auto name = "pclmulqdq";
 
@@ -155,7 +156,7 @@ namespace cpuid
 
             namespace dtes64
             {
-                constexpr const auto mask = 0x00000004U;
+                constexpr const auto mask = 0x00000004ULL;
                 constexpr const auto from = 2;
                 constexpr const auto name = "dtes64";
 
@@ -165,7 +166,7 @@ namespace cpuid
 
             namespace monitor
             {
-                constexpr const auto mask = 0x00000008U;
+                constexpr const auto mask = 0x00000008ULL;
                 constexpr const auto from = 3;
                 constexpr const auto name = "monitor";
 
@@ -175,7 +176,7 @@ namespace cpuid
 
             namespace ds_cpl
             {
-                constexpr const auto mask = 0x00000010U;
+                constexpr const auto mask = 0x00000010ULL;
                 constexpr const auto from = 4;
                 constexpr const auto name = "ds_cpl";
 
@@ -185,7 +186,7 @@ namespace cpuid
 
             namespace vmx
             {
-                constexpr const auto mask = 0x00000020U;
+                constexpr const auto mask = 0x00000020ULL;
                 constexpr const auto from = 5;
                 constexpr const auto name = "vmx";
 
@@ -195,7 +196,7 @@ namespace cpuid
 
             namespace smx
             {
-                constexpr const auto mask = 0x00000040U;
+                constexpr const auto mask = 0x00000040ULL;
                 constexpr const auto from = 6;
                 constexpr const auto name = "smx";
 
@@ -205,7 +206,7 @@ namespace cpuid
 
             namespace eist
             {
-                constexpr const auto mask = 0x00000080U;
+                constexpr const auto mask = 0x00000080ULL;
                 constexpr const auto from = 7;
                 constexpr const auto name = "eist";
 
@@ -215,7 +216,7 @@ namespace cpuid
 
             namespace tm2
             {
-                constexpr const auto mask = 0x00000100U;
+                constexpr const auto mask = 0x00000100ULL;
                 constexpr const auto from = 8;
                 constexpr const auto name = "tm2";
 
@@ -225,7 +226,7 @@ namespace cpuid
 
             namespace ssse3
             {
-                constexpr const auto mask = 0x00000200U;
+                constexpr const auto mask = 0x00000200ULL;
                 constexpr const auto from = 9;
                 constexpr const auto name = "ssse3";
 
@@ -235,7 +236,7 @@ namespace cpuid
 
             namespace cnxt_id
             {
-                constexpr const auto mask = 0x00000400U;
+                constexpr const auto mask = 0x00000400ULL;
                 constexpr const auto from = 10;
                 constexpr const auto name = "cnxt_id";
 
@@ -245,7 +246,7 @@ namespace cpuid
 
             namespace sdbg
             {
-                constexpr const auto mask = 0x00000800U;
+                constexpr const auto mask = 0x00000800ULL;
                 constexpr const auto from = 11;
                 constexpr const auto name = "sdbg";
 
@@ -255,7 +256,7 @@ namespace cpuid
 
             namespace fma
             {
-                constexpr const auto mask = 0x00001000U;
+                constexpr const auto mask = 0x00001000ULL;
                 constexpr const auto from = 12;
                 constexpr const auto name = "fma";
 
@@ -265,7 +266,7 @@ namespace cpuid
 
             namespace cmpxchg16b
             {
-                constexpr const auto mask = 0x00002000U;
+                constexpr const auto mask = 0x00002000ULL;
                 constexpr const auto from = 13;
                 constexpr const auto name = "cmpxchg16b";
 
@@ -275,7 +276,7 @@ namespace cpuid
 
             namespace xtpr_update_control
             {
-                constexpr const auto mask = 0x00004000U;
+                constexpr const auto mask = 0x00004000ULL;
                 constexpr const auto from = 14;
                 constexpr const auto name = "xtpr_update_control";
 
@@ -285,7 +286,7 @@ namespace cpuid
 
             namespace pdcm
             {
-                constexpr const auto mask = 0x00008000U;
+                constexpr const auto mask = 0x00008000ULL;
                 constexpr const auto from = 15;
                 constexpr const auto name = "pdcm";
 
@@ -295,7 +296,7 @@ namespace cpuid
 
             namespace pcid
             {
-                constexpr const auto mask = 0x00020000U;
+                constexpr const auto mask = 0x00020000ULL;
                 constexpr const auto from = 17;
                 constexpr const auto name = "pcid";
 
@@ -305,7 +306,7 @@ namespace cpuid
 
             namespace dca
             {
-                constexpr const auto mask = 0x00040000U;
+                constexpr const auto mask = 0x00040000ULL;
                 constexpr const auto from = 18;
                 constexpr const auto name = "dca";
 
@@ -315,7 +316,7 @@ namespace cpuid
 
             namespace sse41
             {
-                constexpr const auto mask = 0x00080000U;
+                constexpr const auto mask = 0x00080000ULL;
                 constexpr const auto from = 19;
                 constexpr const auto name = "sse41";
 
@@ -325,7 +326,7 @@ namespace cpuid
 
             namespace sse42
             {
-                constexpr const auto mask = 0x00100000U;
+                constexpr const auto mask = 0x00100000ULL;
                 constexpr const auto from = 20;
                 constexpr const auto name = "sse42";
 
@@ -335,7 +336,7 @@ namespace cpuid
 
             namespace x2apic
             {
-                constexpr const auto mask = 0x00200000U;
+                constexpr const auto mask = 0x00200000ULL;
                 constexpr const auto from = 21;
                 constexpr const auto name = "x2apic";
 
@@ -345,7 +346,7 @@ namespace cpuid
 
             namespace movbe
             {
-                constexpr const auto mask = 0x00400000U;
+                constexpr const auto mask = 0x00400000ULL;
                 constexpr const auto from = 22;
                 constexpr const auto name = "movbe";
 
@@ -355,7 +356,7 @@ namespace cpuid
 
             namespace popcnt
             {
-                constexpr const auto mask = 0x00800000U;
+                constexpr const auto mask = 0x00800000ULL;
                 constexpr const auto from = 23;
                 constexpr const auto name = "popcnt";
 
@@ -365,7 +366,7 @@ namespace cpuid
 
             namespace tsc_deadline
             {
-                constexpr const auto mask = 0x01000000U;
+                constexpr const auto mask = 0x01000000ULL;
                 constexpr const auto from = 24;
                 constexpr const auto name = "tsc_deadline";
 
@@ -375,7 +376,7 @@ namespace cpuid
 
             namespace aesni
             {
-                constexpr const auto mask = 0x02000000U;
+                constexpr const auto mask = 0x02000000ULL;
                 constexpr const auto from = 25;
                 constexpr const auto name = "aesni";
 
@@ -385,7 +386,7 @@ namespace cpuid
 
             namespace xsave
             {
-                constexpr const auto mask = 0x04000000U;
+                constexpr const auto mask = 0x04000000ULL;
                 constexpr const auto from = 26;
                 constexpr const auto name = "xsave";
 
@@ -395,7 +396,7 @@ namespace cpuid
 
             namespace osxsave
             {
-                constexpr const auto mask = 0x08000000U;
+                constexpr const auto mask = 0x08000000ULL;
                 constexpr const auto from = 27;
                 constexpr const auto name = "osxsave";
 
@@ -405,7 +406,7 @@ namespace cpuid
 
             namespace avx
             {
-                constexpr const auto mask = 0x10000000U;
+                constexpr const auto mask = 0x10000000ULL;
                 constexpr const auto from = 28;
                 constexpr const auto name = "avx";
 
@@ -415,7 +416,7 @@ namespace cpuid
 
             namespace f16c
             {
-                constexpr const auto mask = 0x20000000U;
+                constexpr const auto mask = 0x20000000ULL;
                 constexpr const auto from = 29;
                 constexpr const auto name = "f16c";
 
@@ -425,7 +426,7 @@ namespace cpuid
 
             namespace rdrand
             {
-                constexpr const auto mask = 0x40000000U;
+                constexpr const auto mask = 0x40000000ULL;
                 constexpr const auto from = 30;
                 constexpr const auto name = "rdrand";
 
@@ -538,6 +539,19 @@ namespace cpuid
 
         namespace subleaf0
         {
+            namespace eax
+            {
+                namespace max_input
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_input";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
             namespace ebx
             {
                 namespace fsgsbase
@@ -547,16 +561,7 @@ namespace cpuid
                     constexpr const auto name = "fsgsbase";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace ia32_tsc_adjust
@@ -566,16 +571,7 @@ namespace cpuid
                     constexpr const auto name = "ia32_tsc_adjust";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace sgx
@@ -585,16 +581,7 @@ namespace cpuid
                     constexpr const auto name = "sgx";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace bmi1
@@ -604,16 +591,7 @@ namespace cpuid
                     constexpr const auto name = "bmi1";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace hle
@@ -623,16 +601,7 @@ namespace cpuid
                     constexpr const auto name = "hle";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace avx2
@@ -642,35 +611,17 @@ namespace cpuid
                     constexpr const auto name = "avx2";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace fdp_excptn_only
                 {
                     constexpr const auto mask = 0x00000040ULL;
                     constexpr const auto from = 6;
-                    constexpr const auto name = "fdp_excptn_only";
+                    constexpr const auto name = "fdb_excptn_only";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace smep
@@ -680,16 +631,7 @@ namespace cpuid
                     constexpr const auto name = "smep";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace bmi2
@@ -699,35 +641,17 @@ namespace cpuid
                     constexpr const auto name = "bmi2";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
-                namespace enhanced_rep
+                namespace movsb
                 {
                     constexpr const auto mask = 0x00000200ULL;
                     constexpr const auto from = 9;
-                    constexpr const auto name = "enhanced_rep";
+                    constexpr const auto name = "movsb";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace invpcid
@@ -737,16 +661,7 @@ namespace cpuid
                     constexpr const auto name = "invpcid";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace rtm
@@ -756,54 +671,27 @@ namespace cpuid
                     constexpr const auto name = "rtm";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
-                namespace rdt_m
+                namespace rtm_m
                 {
                     constexpr const auto mask = 0x00001000ULL;
                     constexpr const auto from = 12;
-                    constexpr const auto name = "rdt_m";
+                    constexpr const auto name = "rtm_m";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
-                namespace depreciated_fpu_cs_ds
+                namespace fpucs_fpuds
                 {
                     constexpr const auto mask = 0x00002000ULL;
                     constexpr const auto from = 13;
-                    constexpr const auto name = "depreciated_fpu_cs_ds";
+                    constexpr const auto name = "fpucs_fpuds";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace mpx
@@ -813,16 +701,7 @@ namespace cpuid
                     constexpr const auto name = "mpx";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace rdt_a
@@ -832,16 +711,7 @@ namespace cpuid
                     constexpr const auto name = "rdt_a";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace rdseed
@@ -851,16 +721,7 @@ namespace cpuid
                     constexpr const auto name = "rdseed";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace adx
@@ -870,16 +731,7 @@ namespace cpuid
                     constexpr const auto name = "adx";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace smap
@@ -889,16 +741,7 @@ namespace cpuid
                     constexpr const auto name = "smap";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace clflushopt
@@ -908,16 +751,7 @@ namespace cpuid
                     constexpr const auto name = "clflushopt";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace clwb
@@ -927,35 +761,17 @@ namespace cpuid
                     constexpr const auto name = "clwb";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
-                namespace processor_trace
+                namespace trace
                 {
                     constexpr const auto mask = 0x02000000ULL;
                     constexpr const auto from = 25;
-                    constexpr const auto name = "processor_trace";
+                    constexpr const auto name = "trace";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
-
-                        _cpuid(&eax, &ebx, &ecx, &edx);
-
-                        return (ebx & mask) != 0;
-                    }
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
                 }
 
                 namespace sha
@@ -965,94 +781,80 @@ namespace cpuid
                     constexpr const auto name = "sha";
 
                     inline auto get() noexcept
-                    {
-                        value_type eax = addr;
-                        value_type ebx = 0U;
-                        value_type ecx = 0U;
-                        value_type edx = 0U;
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+            }
 
-                        _cpuid(&eax, &ebx, &ecx, &edx);
+            namespace ecx
+            {
+                namespace prefetchwt1
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "prefetchwt1";
 
-                        return (ebx & mask) != 0;
-                    }
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
                 }
 
-                inline void dump() noexcept
+                namespace umip
                 {
-                    bfdebug << "cpuid::extended_feature_flags::subleaf0::ebx enabled flags:" << bfendl;
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "umip";
 
-                    if (fsgsbase::get()) {
-                        bfdebug << "    - fsgsbase" << bfendl;
-                    }
-                    if (ia32_tsc_adjust::get()) {
-                        bfdebug << "    - ia32_tsc_adjust" << bfendl;
-                    }
-                    if (sgx::get()) {
-                        bfdebug << "    - sgx" << bfendl;
-                    }
-                    if (bmi1::get()) {
-                        bfdebug << "    - bmi1" << bfendl;
-                    }
-                    if (hle::get()) {
-                        bfdebug << "    - hle" << bfendl;
-                    }
-                    if (avx2::get()) {
-                        bfdebug << "    - avx2" << bfendl;
-                    }
-                    if (fdp_excptn_only::get()) {
-                        bfdebug << "    - fdp_excptn_only" << bfendl;
-                    }
-                    if (smep::get()) {
-                        bfdebug << "    - smep" << bfendl;
-                    }
-                    if (bmi2::get()) {
-                        bfdebug << "    - bmi2" << bfendl;
-                    }
-                    if (enhanced_rep::get()) {
-                        bfdebug << "    - enhanced_rep" << bfendl;
-                    }
-                    if (invpcid::get()) {
-                        bfdebug << "    - invpcid" << bfendl;
-                    }
-                    if (rtm::get()) {
-                        bfdebug << "    - rtm" << bfendl;
-                    }
-                    if (rtm::get()) {
-                        bfdebug << "    - rtm" << bfendl;
-                    }
-                    if (rdt_m::get()) {
-                        bfdebug << "    - rdt_m" << bfendl;
-                    }
-                    if (depreciated_fpu_cs_ds::get()) {
-                        bfdebug << "    - depreciated_fpu_cs_ds" << bfendl;
-                    }
-                    if (mpx::get()) {
-                        bfdebug << "    - mpx" << bfendl;
-                    }
-                    if (rdt_a::get()) {
-                        bfdebug << "    - rdt_a" << bfendl;
-                    }
-                    if (rdseed::get()) {
-                        bfdebug << "    - rdseed" << bfendl;
-                    }
-                    if (adx::get()) {
-                        bfdebug << "    - adx" << bfendl;
-                    }
-                    if (smap::get()) {
-                        bfdebug << "    - smap" << bfendl;
-                    }
-                    if (clflushopt::get()) {
-                        bfdebug << "    - clflushopt" << bfendl;
-                    }
-                    if (clwb::get()) {
-                        bfdebug << "    - clwb" << bfendl;
-                    }
-                    if (processor_trace::get()) {
-                        bfdebug << "    - processor_trace" << bfendl;
-                    }
-                    if (sha::get()) {
-                        bfdebug << "    - sha" << bfendl;
-                    }
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace pku
+                {
+                    constexpr const auto mask = 0x00000008ULL;
+                    constexpr const auto from = 3;
+                    constexpr const auto name = "pku";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace ospke
+                {
+                    constexpr const auto mask = 0x00000010ULL;
+                    constexpr const auto from = 4;
+                    constexpr const auto name = "ospke";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace mawau
+                {
+                    constexpr const auto mask = 0x003E0000ULL;
+                    constexpr const auto from = 17;
+                    constexpr const auto name = "mawau";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+
+                namespace rdpid
+                {
+                    constexpr const auto mask = 0x00400000ULL;
+                    constexpr const auto from = 22;
+                    constexpr const auto name = "rdpid";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace sgx_lc
+                {
+                    constexpr const auto mask = 0x40000000ULL;
+                    constexpr const auto from = 30;
+                    constexpr const auto name = "sgx_lc";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
                 }
             }
         }
@@ -1060,14 +862,14 @@ namespace cpuid
 
     namespace arch_perf_monitoring
     {
-        constexpr const auto addr = 0x0000000AUL;
+        constexpr const auto addr = 0x0000000AULL;
         constexpr const auto name = "arch_perf_monitoring";
 
         namespace eax
         {
             namespace version_id
             {
-                constexpr const auto mask = 0x000000FFUL;
+                constexpr const auto mask = 0x000000FFULL;
                 constexpr const auto from = 0UL;
                 constexpr const auto name = "version_id";
 
@@ -1077,7 +879,7 @@ namespace cpuid
 
             namespace gppmc_count
             {
-                constexpr const auto mask = 0x0000FF00UL;
+                constexpr const auto mask = 0x0000FF00ULL;
                 constexpr const auto from = 8UL;
                 constexpr const auto name = "gppmc_count";
 
@@ -1087,7 +889,7 @@ namespace cpuid
 
             namespace gppmc_bit_width
             {
-                constexpr const auto mask = 0x00FF0000UL;
+                constexpr const auto mask = 0x00FF0000ULL;
                 constexpr const auto from = 16UL;
                 constexpr const auto name = "gppmc_bit_width";
 
@@ -1097,7 +899,7 @@ namespace cpuid
 
             namespace ebx_enumeration_length
             {
-                constexpr const auto mask = 0xFF000000UL;
+                constexpr const auto mask = 0xFF000000ULL;
                 constexpr const auto from = 24;
                 constexpr const auto name = "ebx_enumeration_length";
 
@@ -1110,72 +912,72 @@ namespace cpuid
         {
             namespace core_cycle_event
             {
-                constexpr const auto mask = 0x00000001UL;
-                constexpr const auto from = 0UL;
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0ULL;
                 constexpr const auto name = "core_cycle_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace instr_retired_event
             {
-                constexpr const auto mask = 0x00000002UL;
-                constexpr const auto from = 1UL;
+                constexpr const auto mask = 0x00000002ULL;
+                constexpr const auto from = 1ULL;
                 constexpr const auto name = "instr_retired_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace reference_cycles_event
             {
-                constexpr const auto mask = 0x00000004UL;
-                constexpr const auto from = 2UL;
+                constexpr const auto mask = 0x00000004ULL;
+                constexpr const auto from = 2ULL;
                 constexpr const auto name = "reference_cycles_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace llc_reference_event
             {
-                constexpr const auto mask = 0x00000008UL;
-                constexpr const auto from = 3UL;
+                constexpr const auto mask = 0x00000008ULL;
+                constexpr const auto from = 3ULL;
                 constexpr const auto name = "llc_reference_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace llc_misses_event
             {
-                constexpr const auto mask = 0x00000010UL;
-                constexpr const auto from = 4UL;
+                constexpr const auto mask = 0x00000010ULL;
+                constexpr const auto from = 4ULL;
                 constexpr const auto name = "llc_misses_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace branch_instr_retired_event
             {
-                constexpr const auto mask = 0x00000020UL;
-                constexpr const auto from = 5UL;
+                constexpr const auto mask = 0x00000020ULL;
+                constexpr const auto from = 5ULL;
                 constexpr const auto name = "branch_instr_retired_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
 
             namespace branch_mispredict_retired_event
             {
-                constexpr const auto mask = 0x00000040UL;
-                constexpr const auto from = 6UL;
+                constexpr const auto mask = 0x00000040ULL;
+                constexpr const auto from = 6ULL;
                 constexpr const auto name = "branch_mispredict_retired_event";
 
-                inline auto is_available() noexcept
-                { return get_bit(_cpuid_ebx(addr), from) == 0; }
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ebx(addr), from) != 0; }
             }
         }
 
@@ -1183,7 +985,7 @@ namespace cpuid
         {
             namespace ffpmc_count
             {
-                constexpr const auto mask = 0x0000001FUL;
+                constexpr const auto mask = 0x0000001FULL;
                 constexpr const auto from = 0;
                 constexpr const auto name = "ffpmc_count";
 
@@ -1193,9 +995,221 @@ namespace cpuid
 
             namespace ffpmc_bit_width
             {
-                constexpr const auto mask = 0x00001FE0UL;
+                constexpr const auto mask = 0x00001FE0ULL;
                 constexpr const auto from = 5;
                 constexpr const auto name = "ffpmc_bit_width";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace basic_cpuid_info
+    {
+        constexpr const auto addr = 0x00000000ULL;
+        constexpr const auto name = "basic_cpuid_info";
+
+        namespace eax
+        {
+            namespace max_input_value
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "max_input_value";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace extend_cpuid_info
+    {
+        constexpr const auto addr = 0x80000000ULL;
+        constexpr const auto name = "extend_cpuid_info";
+
+        namespace eax
+        {
+            namespace max_input_value
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "max_input_value";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace processor_string_1
+    {
+        constexpr const auto addr = 0x80000002ULL;
+        constexpr const auto name = "processor_string_1";
+
+        namespace eax
+        {
+            namespace part_1
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_1";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace part_2
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_2";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace part_3
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_3";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace part_4
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_4";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace processor_string_2
+    {
+        constexpr const auto addr = 0x80000003ULL;
+        constexpr const auto name = "processor_string_2";
+
+        namespace eax
+        {
+            namespace part_1
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_1";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace part_2
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_2";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace part_3
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_3";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace part_4
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_4";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace processor_string_3
+    {
+        constexpr const auto addr = 0x80000004ULL;
+        constexpr const auto name = "processor_string_3";
+
+        namespace eax
+        {
+            namespace part_1
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_1";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace part_2
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_2";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace part_3
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_3";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace part_4
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part_4";
 
                 inline auto get() noexcept
                 { return get_bits(_cpuid_edx(addr), mask) >> from; }

--- a/include/intrinsics/x86/intel/cpuid/cpuid_intel_x64.h
+++ b/include/intrinsics/x86/intel/cpuid/cpuid_intel_x64.h
@@ -1,0 +1,1876 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef CPUID_INTEL_X64_H
+#define CPUID_INTEL_X64_H
+
+#include <intrinsics/x86/common/cpuid/cpuid_x64.h>
+
+namespace x64
+{
+namespace cpuid
+{
+namespace intel
+{
+    namespace cache_tlb_info
+    {
+        constexpr const auto addr = 0x00000002ULL;
+        constexpr const auto name = "cache_tlb_info";
+
+        namespace eax
+        {
+            namespace info
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "info";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace info
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "info";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace info
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "info";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace info
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "info";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace serial_num
+    {
+        constexpr const auto addr = 0x00000003ULL;
+        constexpr const auto name = "serial_num";
+
+        namespace ecx
+        {
+            namespace bits
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "bits";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace bits
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "bits";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace cache_parameters
+    {
+        constexpr const auto addr = 0x00000004ULL;
+        constexpr const auto name = "cache_parameters";
+
+        namespace eax
+        {
+            namespace cache_type
+            {
+                constexpr const auto mask = 0x0000001FULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "cache_type";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace cache_level
+            {
+                constexpr const auto mask = 0x000000E0ULL;
+                constexpr const auto from = 5;
+                constexpr const auto name = "cache_level";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace self_init_level
+            {
+                constexpr const auto mask = 0x00000100ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "self_init_level";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace fully_associative
+            {
+                constexpr const auto mask = 0x00000200ULL;
+                constexpr const auto from = 9;
+                constexpr const auto name = "fully_associative";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace max_ids_logical
+            {
+                constexpr const auto mask = 0x03FFC000ULL;
+                constexpr const auto from = 14;
+                constexpr const auto name = "max_ids_logical";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace max_ids_physical
+            {
+                constexpr const auto mask = 0xFC000000ULL;
+                constexpr const auto from = 26;
+                constexpr const auto name = "max_ids_physical";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace l
+            {
+                constexpr const auto mask = 0x00000FFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "l";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+
+            namespace p
+            {
+                constexpr const auto mask = 0x003FF000ULL;
+                constexpr const auto from = 12;
+                constexpr const auto name = "p";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+
+            namespace w
+            {
+                constexpr const auto mask = 0xFFC00000ULL;
+                constexpr const auto from = 22;
+                constexpr const auto name = "w";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace num_sets
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "num_sets";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace wbinvd_invd
+            {
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "wbinvd_invd";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace cache_inclusiveness
+            {
+                constexpr const auto mask = 0x00000002ULL;
+                constexpr const auto from = 1;
+                constexpr const auto name = "cache_inclusiveness";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace complex_cache_indexing
+            {
+                constexpr const auto mask = 0x00000004ULL;
+                constexpr const auto from = 2;
+                constexpr const auto name = "complex_cache_indexing";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+        }
+    }
+
+    namespace monitor_mwait
+    {
+        constexpr const auto addr = 0x00000005ULL;
+        constexpr const auto name = "monitor_mwait";
+
+        namespace eax
+        {
+            namespace min_line_size
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "min_line_size";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace max_line_size
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "max_line_size";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace enum_mwait_extensions
+            {
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "enum_mwait_extensions";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+
+            namespace interrupt_break_event
+            {
+                constexpr const auto mask = 0x00000002ULL;
+                constexpr const auto from = 1;
+                constexpr const auto name = "interrupt_break_event";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace num_c0
+            {
+                constexpr const auto mask = 0x0000000FULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "num_c0";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c1
+            {
+                constexpr const auto mask = 0x000000F0ULL;
+                constexpr const auto from = 4;
+                constexpr const auto name = "num_c1";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c2
+            {
+                constexpr const auto mask = 0x00000F00ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "num_c2";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c3
+            {
+                constexpr const auto mask = 0x0000F000ULL;
+                constexpr const auto from = 12;
+                constexpr const auto name = "num_c3";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c4
+            {
+                constexpr const auto mask = 0x000F0000ULL;
+                constexpr const auto from = 16;
+                constexpr const auto name = "num_c4";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c5
+            {
+                constexpr const auto mask = 0x00F00000ULL;
+                constexpr const auto from = 20;
+                constexpr const auto name = "num_c5";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c6
+            {
+                constexpr const auto mask = 0x0F000000ULL;
+                constexpr const auto from = 24;
+                constexpr const auto name = "num_c6";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace num_c7
+            {
+                constexpr const auto mask = 0xF0000000ULL;
+                constexpr const auto from = 28;
+                constexpr const auto name = "num_c7";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace therm_power_management
+    {
+        constexpr const auto addr = 0x00000006ULL;
+        constexpr const auto name = "therm_power_management";
+
+        namespace eax
+        {
+            namespace temp_sensor
+            {
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "temp_sensor";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace intel_turbo
+            {
+                constexpr const auto mask = 0x00000002ULL;
+                constexpr const auto from = 1;
+                constexpr const auto name = "intel_turbo";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace arat
+            {
+                constexpr const auto mask = 0x00000004ULL;
+                constexpr const auto from = 2;
+                constexpr const auto name = "arat";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace pln
+            {
+                constexpr const auto mask = 0x00000010ULL;
+                constexpr const auto from = 4;
+                constexpr const auto name = "pln";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace ecmd
+            {
+                constexpr const auto mask = 0x00000020ULL;
+                constexpr const auto from = 5;
+                constexpr const auto name = "ecmd";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace ptm
+            {
+                constexpr const auto mask = 0x00000040ULL;
+                constexpr const auto from = 6;
+                constexpr const auto name = "ptm";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hwp
+            {
+                constexpr const auto mask = 0x00000080ULL;
+                constexpr const auto from = 7;
+                constexpr const auto name = "hwp";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hwp_notification
+            {
+                constexpr const auto mask = 0x00000100ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "hwp_notification";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hwp_activity_window
+            {
+                constexpr const auto mask = 0x00000200ULL;
+                constexpr const auto from = 9;
+                constexpr const auto name = "hwp_activity_window";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hwp_energy_perf
+            {
+                constexpr const auto mask = 0x00000400ULL;
+                constexpr const auto from = 10;
+                constexpr const auto name = "hwp_energy_perf";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hwp_package_request
+            {
+                constexpr const auto mask = 0x00000800ULL;
+                constexpr const auto from = 11;
+                constexpr const auto name = "hwp_package_request";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+
+            namespace hdc
+            {
+                constexpr const auto mask = 0x00002000ULL;
+                constexpr const auto from = 13;
+                constexpr const auto name = "hdc";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_eax(addr), from) != 0; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace num_interrupts
+            {
+                constexpr const auto mask = 0x0000000FULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "num_interrupts";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace hardware_feedback
+            {
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "hardware_feedback";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+
+            namespace energy_perf_bias
+            {
+                constexpr const auto mask = 0x00000008ULL;
+                constexpr const auto from = 3;
+                constexpr const auto name = "energy_perf_bias";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+        }
+    }
+
+    namespace access_cache
+    {
+        constexpr const auto addr = 0x00000009ULL;
+        constexpr const auto name = "access_cache";
+
+        namespace eax
+        {
+            namespace ia32_platform_dca_cap
+            {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "ia32_platform_dca_cap";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace topology_enumeration
+    {
+        constexpr const auto addr = 0x0000000BULL;
+        constexpr const auto name = "topology_enumeration";
+
+        namespace eax
+        {
+            namespace x2apic_shift
+            {
+                constexpr const auto mask = 0x0000001FULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "x2apic_shift";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace num_processors
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "num_processors";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace level_number
+            {
+                constexpr const auto mask = 0x000000FFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "level_number";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+
+            namespace level_type
+            {
+                constexpr const auto mask = 0x0000FF00ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "level_type";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace x2apic_id
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "x2apic_id";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace extended_state_enum
+    {
+        constexpr const auto addr = 0x0000000DULL;
+        constexpr const auto name = "extended_state_enum";
+
+        namespace mainleaf
+        {
+            namespace eax
+            {
+                namespace supported_bits
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "supported_bits";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace max_size
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace max_size
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace supported_bits
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "supported_bits";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleaf0
+        {
+            namespace eax
+            {
+                namespace xsaveopt
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "xsaveopt";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+
+                namespace xsavec
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "xsavec";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+
+                namespace xgetbv
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "xgetbv";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+
+                namespace xsaves_xrstors
+                {
+                    constexpr const auto mask = 0x00000008ULL;
+                    constexpr const auto from = 3;
+                    constexpr const auto name = "xsaves_xrstors";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace xsave_size
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "xsave_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace supported_bits
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "supported_bits";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace supported_bits
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "supported_bits";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleafn
+        {
+            namespace eax
+            {
+                namespace save_area_size
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "save_area_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace save_area_offset
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "save_area_offset";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace n_supported
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "n_supported";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace location
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "location";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+            }
+        }
+    }
+
+    namespace intel_rdt
+    {
+        constexpr const auto addr = 0x0000000FULL;
+        constexpr const auto name = "intel_rdt";
+
+        namespace subleaf0
+        {
+            namespace ebx
+            {
+                namespace rmid_max_range
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "rmid_max_range";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace l3_rdt
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "l3_rdt";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_edx(addr), from) != 0; }
+                }
+            }
+        }
+
+        namespace subleaf1
+        {
+            namespace ebx
+            {
+                namespace conversion_factor
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "conversion_factor";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace rmid_max_range
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "rmid_max_range";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace l3_occupancy
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "l3_occupancy";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_edx(addr), from) != 0; }
+                }
+
+                namespace l3_total_bandwith
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "l3_total_bandwith";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_edx(addr), from) != 0; }
+                }
+
+                namespace l3_local_bandwith
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "l3_local_bandwith";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_edx(addr), from) != 0; }
+                }
+            }
+        }
+    }
+
+    namespace allocation_enumeration
+    {
+        constexpr const auto addr = 0x00000010ULL;
+        constexpr const auto name = "allocation_enumeration";
+
+        namespace subleaf0
+        {
+            namespace ebx
+            {
+                namespace l3_cache
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "l3_cache";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace l2_cache
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "l2_cache";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace mem_bandwidth
+                {
+                    constexpr const auto mask = 0x00000008ULL;
+                    constexpr const auto from = 3;
+                    constexpr const auto name = "mem_bandwidth";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+            }
+        }
+
+        namespace subleaf1
+        {
+            namespace eax
+            {
+                namespace mask_length
+                {
+                    constexpr const auto mask = 0x0000001FULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "mask_length";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace map
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "map";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace data_prio
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "data_prio";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace max_cos
+                {
+                    constexpr const auto mask = 0x0000FFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_cos";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleaf2
+        {
+            namespace eax
+            {
+                namespace mask_length
+                {
+                    constexpr const auto mask = 0x0000001FULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "mask_length";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace map
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "map";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace max_cos
+                {
+                    constexpr const auto mask = 0x0000FFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_cos";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleaf3
+        {
+            namespace eax
+            {
+                namespace max_throttle
+                {
+                    constexpr const auto mask = 0x00000FFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_throttle";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace linear
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "linear";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace max_cos
+                {
+                    constexpr const auto mask = 0x0000FFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_cos";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+    }
+
+    namespace intel_sgx
+    {
+        constexpr const auto addr = 0x00000012ULL;
+        constexpr const auto name = "intel_sgx";
+
+        namespace subleaf0
+        {
+            namespace eax
+            {
+                namespace sgx1
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "sgx1";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+
+                namespace sgx2
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "sgx2";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_eax(addr), from) != 0; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace miscselect
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "miscselect";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace mes_not64
+                {
+                    constexpr const auto mask = 0x000000FFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "mes_not64";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+
+                namespace mes_64
+                {
+                    constexpr const auto mask = 0x0000FF00ULL;
+                    constexpr const auto from = 8;
+                    constexpr const auto name = "mes_64";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleaf1
+        {
+            namespace part1
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part1";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace part2
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part2";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+
+            namespace part3
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part3";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+
+            namespace part4
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "part4";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_edx(addr), mask) >> from; }
+            }
+        }
+
+        namespace subleaf2
+        {
+            namespace eax
+            {
+                namespace subleaf_type
+                {
+                    constexpr const auto mask = 0x0000000FULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "subleaf_type";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+
+                namespace address
+                {
+                    constexpr const auto mask = 0xFFFFF000ULL;
+                    constexpr const auto from = 12;
+                    constexpr const auto name = "address";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace address
+                {
+                    constexpr const auto mask = 0x000FFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "address";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace epc_property
+                {
+                    constexpr const auto mask = 0x0000000FULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "epc_property";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+
+                namespace epc_size
+                {
+                    constexpr const auto mask = 0xFFFFF000ULL;
+                    constexpr const auto from = 12;
+                    constexpr const auto name = "epc_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace epc_size
+                {
+                    constexpr const auto mask = 0x000FFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "epc_size";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+    }
+
+    namespace trace_enumeration
+    {
+        constexpr const auto addr = 0x00000014ULL;
+        constexpr const auto name = "trace_enumeration";
+
+        namespace mainleaf
+        {
+            namespace eax
+            {
+                namespace max_subleaf
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "max_subleaf";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace ia32_rtit_ctlcr3filter
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "ia32_rtit_ctlcr3filter";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace configurable_psb
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "configurable_psb";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace ip_filtering
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "ip_filtering";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace mtc_timing_packet
+                {
+                    constexpr const auto mask = 0x00000008ULL;
+                    constexpr const auto from = 3;
+                    constexpr const auto name = "mtc_timing_packet";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace ptwrite
+                {
+                    constexpr const auto mask = 0x00000010ULL;
+                    constexpr const auto from = 4;
+                    constexpr const auto name = "ptwrite";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+
+                namespace power_event_trace
+                {
+                    constexpr const auto mask = 0x00000020ULL;
+                    constexpr const auto from = 5;
+                    constexpr const auto name = "power_event_trace";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace trading_enabled
+                {
+                    constexpr const auto mask = 0x00000001ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "trading_enabled";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace topa_entry
+                {
+                    constexpr const auto mask = 0x00000002ULL;
+                    constexpr const auto from = 1;
+                    constexpr const auto name = "topa_entry";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace single_range_output
+                {
+                    constexpr const auto mask = 0x00000004ULL;
+                    constexpr const auto from = 2;
+                    constexpr const auto name = "single_range_output";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace trace_transport
+                {
+                    constexpr const auto mask = 0x00000008ULL;
+                    constexpr const auto from = 3;
+                    constexpr const auto name = "trace_transport";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+
+                namespace lip_values
+                {
+                    constexpr const auto mask = 0x80000000ULL;
+                    constexpr const auto from = 31;
+                    constexpr const auto name = "lip_values";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ecx(addr), from) != 0; }
+                }
+            }
+        }
+
+        namespace subleaf
+        {
+            namespace eax
+            {
+                namespace num_address_ranges
+                {
+                    constexpr const auto mask = 0x00000007ULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "num_address_ranges";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+
+                namespace bitmap_mtc
+                {
+                    constexpr const auto mask = 0xFFFF0000ULL;
+                    constexpr const auto from = 16;
+                    constexpr const auto name = "bitmap_mtc";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace bitmap_cycle_threshold
+                {
+                    constexpr const auto mask = 0x0000FFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "bitmap_cycle_threshold";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+
+                namespace bitmap_psb
+                {
+                    constexpr const auto mask = 0xFFFF0000ULL;
+                    constexpr const auto from = 16;
+                    constexpr const auto name = "bitmap_psb";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+        }
+    }
+
+    namespace time_stamp_count
+    {
+        constexpr const auto addr = 0x00000015ULL;
+        constexpr const auto name = "time_stamp_count";
+
+        namespace eax
+        {
+            namespace tsc_denom
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "tsc_denom";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace tsc_numer
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "tsc_numer";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace nominal_freq
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "nominal_freq";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace processor_freq
+    {
+        constexpr const auto addr = 0x00000016ULL;
+        constexpr const auto name = "processor_freq";
+
+        namespace eax
+        {
+            namespace base_freq
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "base_freq";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace max_freq
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "max_freq";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+            }
+        }
+
+        namespace ecx
+        {
+            namespace bus_freq
+            {
+                constexpr const auto mask = 0x0000FFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "bus_freq";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace vendor_attribute
+    {
+        constexpr const auto addr = 0x00000017ULL;
+        constexpr const auto name = "vendor_attribute";
+
+        namespace mainleaf
+        {
+            namespace max_socid
+            {
+                constexpr const auto mask = 0xFFFFFFFFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "max_socid";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace ebx
+            {
+                namespace soc_vendor
+                {
+                    constexpr const auto mask = 0x0000FFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "soc_vendor";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+
+                namespace is_vendor_scheme
+                {
+                    constexpr const auto mask = 0x00010000ULL;
+                    constexpr const auto from = 16;
+                    constexpr const auto name = "is_vendor_scheme";
+
+                    inline auto get() noexcept
+                    { return get_bit(_cpuid_ebx(addr), from) != 0; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace project_id
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "project_id";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace stepping_id
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "stepping_id";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+
+        namespace subleaf1
+        {
+            namespace eax
+            {
+                namespace brand_string
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "brand_string";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_eax(addr), mask) >> from; }
+                }
+            }
+
+            namespace ebx
+            {
+                namespace brand_string
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "brand_string";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ebx(addr), mask) >> from; }
+                }
+            }
+
+            namespace ecx
+            {
+                namespace brand_string
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "brand_string";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+                }
+            }
+
+            namespace edx
+            {
+                namespace brand_string
+                {
+                    constexpr const auto mask = 0xFFFFFFFFULL;
+                    constexpr const auto from = 0;
+                    constexpr const auto name = "brand_string";
+
+                    inline auto get() noexcept
+                    { return get_bits(_cpuid_edx(addr), mask) >> from; }
+                }
+            }
+        }
+    }
+
+    namespace ext_feature_info
+    {
+        constexpr const auto addr = 0x80000001ULL;
+        constexpr const auto name = "ext_feature_info";
+
+        namespace ecx
+        {
+            namespace lahf_sahf
+            {
+                constexpr const auto mask = 0x00000001ULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "lahf_sahf";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+
+            namespace lzcnt
+            {
+                constexpr const auto mask = 0x00000020ULL;
+                constexpr const auto from = 5;
+                constexpr const auto name = "lzcnt";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+
+            namespace prefetchw
+            {
+                constexpr const auto mask = 0x00000100ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "prefetchw";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_ecx(addr), from) != 0; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace syscall_sysret
+            {
+                constexpr const auto mask = 0x00000800ULL;
+                constexpr const auto from = 11;
+                constexpr const auto name = "syscall_sysret";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace execute_disable_bit
+            {
+                constexpr const auto mask = 0x00100000ULL;
+                constexpr const auto from = 20;
+                constexpr const auto name = "execute_disable_bit";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace pages_avail
+            {
+                constexpr const auto mask = 0x04000000ULL;
+                constexpr const auto from = 26;
+                constexpr const auto name = "pages_avail";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace rdtscp
+            {
+                constexpr const auto mask = 0x08000000ULL;
+                constexpr const auto from = 27;
+                constexpr const auto name = "rdtscp";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+
+            namespace intel_64
+            {
+                constexpr const auto mask = 0x20000000ULL;
+                constexpr const auto from = 29;
+                constexpr const auto name = "intel_64";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+        }
+    }
+
+    namespace l2_info
+    {
+        constexpr const auto addr = 0x80000006ULL;
+        constexpr const auto name = "l2_info";
+
+        namespace ecx
+        {
+            namespace line_size
+            {
+                constexpr const auto mask = 0x000000FFULL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "line_size";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+
+            namespace l2_associativity
+            {
+                constexpr const auto mask = 0x0000F000ULL;
+                constexpr const auto from = 12;
+                constexpr const auto name = "l2_associativity";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+
+            namespace cache_size
+            {
+                constexpr const auto mask = 0xFFFF0000ULL;
+                constexpr const auto from = 16;
+                constexpr const auto name = "cache_size";
+
+                inline auto get() noexcept
+                { return get_bits(_cpuid_ecx(addr), mask) >> from; }
+            }
+        }
+    }
+
+    namespace invariant_tsc
+    {
+        constexpr const auto addr = 0x80000007ULL;
+        constexpr const auto name = "invariant_tsc";
+
+        namespace edx
+        {
+            namespace available
+            {
+                constexpr const auto mask = 0x00000100ULL;
+                constexpr const auto from = 8;
+                constexpr const auto name = "available";
+
+                inline auto get() noexcept
+                { return get_bit(_cpuid_edx(addr), from) != 0; }
+            }
+        }
+    }
+}
+}
+}
+
+#endif

--- a/include/intrinsics/x86/intel_x64.h
+++ b/include/intrinsics/x86/intel_x64.h
@@ -26,5 +26,6 @@
 #include <intrinsics/x86/intel/msrs/msrs_intel_x64.h>
 #include <intrinsics/x86/intel/crs_intel_x64.h>
 #include <intrinsics/x86/intel/vmcs/vmcs_intel_x64.h>
+#include <intrinsics/x86/intel/cpuid/cpuid_intel_x64.h>
 
 #endif

--- a/src/intrinsics/tests/CMakeLists.txt
+++ b/src/intrinsics/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# ------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------
 # CMake Includes
 # ------------------------------------------------------------------------------
 
@@ -9,30 +9,50 @@ include("${CMAKE_INSTALL_PREFIX}/cmake/CMakeOption_Testing.txt")
 # Targets
 # ------------------------------------------------------------------------------
 
-macro(do_test str)
-    add_executable(test_${str} test_${str}.cpp )
+macro(do_test str source)
+    add_executable(test_${str} test_${str}.cpp ${source})
+    target_compile_definitions(test_${str} PRIVATE STATIC_INTRINSICS)
+    target_link_libraries(test_${str} bfvmm_catch_static)
     add_test(test_${str} test_${str})
 endmacro(do_test)
 
-do_test(cache_x64)
-do_test(cpuid_x64)
-do_test(crs_intel_x64)
-do_test(debug_x64)
-do_test(gdt_x64)
-do_test(idt_x64)
-do_test(msrs_intel_x64)
-do_test(msrs_x64)
-do_test(pdpte_x64)
-do_test(pm_x64)
-do_test(portio_x64)
-do_test(rdtsc_x64)
-do_test(rflags_x64)
-do_test(srs_x64)
-do_test(tlb_x64)
-# do_test(vmcs_intel_x64)
-do_test(vmcs_intel_x64_check_controls)
-do_test(vmcs_intel_x64_check_guest)
-do_test(vmcs_intel_x64_check_host)
-do_test(vmcs_intel_x64_debug)
-do_test(vmcs_intel_x64_helpers)
-do_test(vmx_intel_x64)
+list(APPEND INTRINSICS_SOURCE
+  ../src/cache_x64_mock.cpp
+  ../src/cpuid_x64_mock.cpp
+  ../src/crs_intel_x64_mock.cpp
+  ../src/debug_x64_mock.cpp
+  ../src/gdt_x64_mock.cpp
+  ../src/idt_x64_mock.cpp
+  ../src/msrs_x64_mock.cpp
+  ../src/pm_x64_mock.cpp
+  ../src/portio_x64_mock.cpp
+  ../src/rdtsc_x64_mock.cpp
+  ../src/rflags_x64_mock.cpp
+  ../src/srs_x64_mock.cpp
+  ../src/thread_context_x64_mock.cpp
+  ../src/tlb_x64_mock.cpp
+  ../src/vmx_intel_x64_mock.cpp
+)
+
+do_test(cache_x64 "${INTRINSICS_SOURCE}")
+do_test(cpuid_x64 "${INTRINSICS_SOURCE}")
+do_test(crs_intel_x64 "${INTRINSICS_SOURCE}")
+do_test(debug_x64 "${INTRINSICS_SOURCE}")
+do_test(gdt_x64 "${INTRINSICS_SOURCE}")
+do_test(idt_x64 "${INTRINSICS_SOURCE}")
+do_test(msrs_intel_x64 "${INTRINSICS_SOURCE}")
+do_test(msrs_x64 "${INTRINSICS_SOURCE}")
+do_test(pdpte_x64 "${INTRINSICS_SOURCE}")
+do_test(pm_x64 "${INTRINSICS_SOURCE}")
+do_test(portio_x64 "${INTRINSICS_SOURCE}")
+do_test(rdtsc_x64 "${INTRINSICS_SOURCE}")
+do_test(rflags_x64 "${INTRINSICS_SOURCE}")
+do_test(srs_x64 "${INTRINSICS_SOURCE}")
+do_test(tlb_x64 "${INTRINSICS_SOURCE}")
+# do_test(vmcs_intel_x64 "${INTRINSICS_SOURCE}")
+do_test(vmcs_intel_x64_check_controls "${INTRINSICS_SOURCE}")
+do_test(vmcs_intel_x64_check_guest "${INTRINSICS_SOURCE}")
+do_test(vmcs_intel_x64_check_host "${INTRINSICS_SOURCE}")
+do_test(vmcs_intel_x64_debug "${INTRINSICS_SOURCE}")
+do_test(vmcs_intel_x64_helpers "${INTRINSICS_SOURCE}")
+do_test(vmx_intel_x64 "${INTRINSICS_SOURCE}")

--- a/src/intrinsics/tests/test_cpuid_x64.cpp
+++ b/src/intrinsics/tests/test_cpuid_x64.cpp
@@ -19,667 +19,2568 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#define CATCH_CONFIG_MAIN
 #include <catch/catch.hpp>
+#include <intrinsics/x86/common_x64.h>
+#include <intrinsics/x86/intel_x64.h>
+#include <map>
+#include <hippomocks.h>
 
-TEST_CASE("test name goes here")
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+using namespace x64;
+
+std::map<cpuid::field_type, cpuid::value_type> g_eax_cpuid;
+std::map<cpuid::field_type, cpuid::value_type> g_ebx_cpuid;
+std::map<cpuid::field_type, cpuid::value_type> g_ecx_cpuid;
+std::map<cpuid::field_type, cpuid::value_type> g_edx_cpuid;
+
+extern "C" uint32_t __cpuid_eax(uint32_t val) noexcept;
+extern "C" uint32_t __cpuid_ebx(uint32_t val) noexcept;
+extern "C" uint32_t __cpuid_ecx(uint32_t val) noexcept;
+extern "C" uint32_t __cpuid_edx(uint32_t val) noexcept;
+extern "C" void __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept;
+
+struct cpuid_regs
 {
-    CHECK(true);
+    cpuid::value_type eax;
+    cpuid::value_type ebx;
+    cpuid::value_type ecx;
+    cpuid::value_type edx;
+};
+
+struct cpuid_regs g_regs;
+
+extern "C" uint32_t
+test_cpuid_eax(uint32_t val) noexcept
+{ return g_eax_cpuid[val]; }
+extern "C" uint32_t
+test_cpuid_ebx(uint32_t val) noexcept
+{ return g_ebx_cpuid[val]; }
+
+extern "C" uint32_t
+test_cpuid_ecx(uint32_t val) noexcept
+{ return g_ecx_cpuid[val]; }
+
+extern "C" uint32_t
+test_cpuid_edx(uint32_t val) noexcept
+{ return g_edx_cpuid[val]; }
+
+extern "C" void
+test_cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
+{
+    *static_cast<cpuid::value_type *>(eax) = g_regs.eax;
+    *static_cast<cpuid::value_type *>(ebx) = g_regs.ebx;
+    *static_cast<cpuid::value_type *>(ecx) = g_regs.ecx;
+    *static_cast<cpuid::value_type *>(edx) = g_regs.edx;
 }
 
-// #include <test.h>
-// #include <intrinsics/cpuid_x64.h>
-
-// using namespace x64;
-
-// std::map<cpuid::field_type, cpuid::value_type> g_eax_cpuid;
-// std::map<cpuid::field_type, cpuid::value_type> g_ebx_cpuid;
-// std::map<cpuid::field_type, cpuid::value_type> g_ecx_cpuid;
-// std::map<cpuid::field_type, cpuid::value_type> g_edx_cpuid;
-
-// extern "C" uint32_t _cpuid_eax(uint32_t val) noexcept;
-// extern "C" uint32_t _cpuid_ebx(uint32_t val) noexcept;
-// extern "C" uint32_t _cpuid_ecx(uint32_t val) noexcept;
-// extern "C" uint32_t _cpuid_edx(uint32_t val) noexcept;
-// extern "C" void _cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept;
-
-// struct cpuid_regs
-// {
-//     cpuid::value_type eax;
-//     cpuid::value_type ebx;
-//     cpuid::value_type ecx;
-//     cpuid::value_type edx;
-// };
-
-// struct cpuid_regs g_regs;
-
-// extern "C" uint32_t
-// _cpuid_eax(uint32_t val) noexcept
-// { return g_eax_cpuid[val]; }
-
-// extern "C" uint32_t
-// _cpuid_ebx(uint32_t val) noexcept
-// { return g_ebx_cpuid[val]; }
-
-// extern "C" uint32_t
-// _cpuid_ecx(uint32_t val) noexcept
-// { return g_ecx_cpuid[val]; }
-
-// extern "C" uint32_t
-// _cpuid_edx(uint32_t val) noexcept
-// { return g_edx_cpuid[val]; }
-
-// extern "C" void
-// _cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
-// {
-//     *static_cast<cpuid::value_type *>(eax) = g_regs.eax;
-//     *static_cast<cpuid::value_type *>(ebx) = g_regs.ebx;
-//     *static_cast<cpuid::value_type *>(ecx) = g_regs.ecx;
-//     *static_cast<cpuid::value_type *>(edx) = g_regs.edx;
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid()
-// {
-//     g_regs.eax = 1U;
-//     g_regs.ebx = 2U;
-//     g_regs.ecx = 3U;
-//     g_regs.edx = 4U;
-
-//     auto ret = cpuid::get(g_regs.eax, g_regs.ebx, g_regs.ecx, g_regs.edx);
-
-//     this->expect_true(std::get<0>(ret) == 1U);
-//     this->expect_true(std::get<1>(ret) == 2U);
-//     this->expect_true(std::get<2>(ret) == 3U);
-//     this->expect_true(std::get<3>(ret) == 4U);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_eax()
-// {
-//     g_eax_cpuid[10U] = 42U;
-//     this->expect_true(cpuid::eax::get(10U) == 42U);
-//     this->expect_true(cpuid::eax::get(10UL) == 42U);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_ebx()
-// {
-//     g_ebx_cpuid[10U] = 42U;
-//     this->expect_true(cpuid::ebx::get(10U) == 42U);
-//     this->expect_true(cpuid::ebx::get(10UL) == 42U);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_ecx()
-// {
-//     g_ecx_cpuid[10U] = 42U;
-//     this->expect_true(cpuid::ecx::get(10U) == 42U);
-//     this->expect_true(cpuid::ecx::get(10UL) == 42U);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_edx()
-// {
-//     g_edx_cpuid[10U] = 42U;
-//     this->expect_true(cpuid::edx::get(10U) == 42U);
-//     this->expect_true(cpuid::edx::get(10UL) == 42U);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_addr_size_phys()
-// {
-//     g_eax_cpuid[cpuid::addr_size::addr] = 0x12345610;
-//     this->expect_true(cpuid::addr_size::phys::get() == 0x10);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_addr_size_linear()
-// {
-//     g_eax_cpuid[cpuid::addr_size::addr] = 0x12341056;
-//     this->expect_true(cpuid::addr_size::linear::get() == 0x10);
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse3()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 0;
-//     this->expect_true(cpuid::feature_information::ecx::sse3::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 0);
-//     this->expect_false(cpuid::feature_information::ecx::sse3::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pclmulqdq()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 1;
-//     this->expect_true(cpuid::feature_information::ecx::pclmulqdq::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 1);
-//     this->expect_false(cpuid::feature_information::ecx::pclmulqdq::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dtes64()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 2;
-//     this->expect_true(cpuid::feature_information::ecx::dtes64::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 2);
-//     this->expect_false(cpuid::feature_information::ecx::dtes64::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_monitor()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 3;
-//     this->expect_true(cpuid::feature_information::ecx::monitor::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 3);
-//     this->expect_false(cpuid::feature_information::ecx::monitor::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_ds_cpl()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 4;
-//     this->expect_true(cpuid::feature_information::ecx::ds_cpl::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 4);
-//     this->expect_false(cpuid::feature_information::ecx::ds_cpl::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_vmx()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 5;
-//     this->expect_true(cpuid::feature_information::ecx::vmx::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 5);
-//     this->expect_false(cpuid::feature_information::ecx::vmx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_smx()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 6;
-//     this->expect_true(cpuid::feature_information::ecx::smx::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 6);
-//     this->expect_false(cpuid::feature_information::ecx::smx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_eist()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 7;
-//     this->expect_true(cpuid::feature_information::ecx::eist::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 7);
-//     this->expect_false(cpuid::feature_information::ecx::eist::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_tm2()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 8;
-//     this->expect_true(cpuid::feature_information::ecx::tm2::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 8);
-//     this->expect_false(cpuid::feature_information::ecx::tm2::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_ssse3()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 9;
-//     this->expect_true(cpuid::feature_information::ecx::ssse3::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 9);
-//     this->expect_false(cpuid::feature_information::ecx::ssse3::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_cnxt_id()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 10;
-//     this->expect_true(cpuid::feature_information::ecx::cnxt_id::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 10);
-//     this->expect_false(cpuid::feature_information::ecx::cnxt_id::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sdbg()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 11;
-//     this->expect_true(cpuid::feature_information::ecx::sdbg::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 11);
-//     this->expect_false(cpuid::feature_information::ecx::sdbg::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_fma()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 12;
-//     this->expect_true(cpuid::feature_information::ecx::fma::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 12);
-//     this->expect_false(cpuid::feature_information::ecx::fma::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_cmpxchg16b()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 13;
-//     this->expect_true(cpuid::feature_information::ecx::cmpxchg16b::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 13);
-//     this->expect_false(cpuid::feature_information::ecx::cmpxchg16b::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_xtpr_update_control()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 14;
-//     this->expect_true(cpuid::feature_information::ecx::xtpr_update_control::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 14);
-//     this->expect_false(cpuid::feature_information::ecx::xtpr_update_control::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pdcm()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 15;
-//     this->expect_true(cpuid::feature_information::ecx::pdcm::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 15);
-//     this->expect_false(cpuid::feature_information::ecx::pdcm::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pcid()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 17;
-//     this->expect_true(cpuid::feature_information::ecx::pcid::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 17);
-//     this->expect_false(cpuid::feature_information::ecx::pcid::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dca()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 18;
-//     this->expect_true(cpuid::feature_information::ecx::dca::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 18);
-//     this->expect_false(cpuid::feature_information::ecx::dca::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse41()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 19;
-//     this->expect_true(cpuid::feature_information::ecx::sse41::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 19);
-//     this->expect_false(cpuid::feature_information::ecx::sse41::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse42()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 20;
-//     this->expect_true(cpuid::feature_information::ecx::sse42::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 20);
-//     this->expect_false(cpuid::feature_information::ecx::sse42::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_x2apic()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 21;
-//     this->expect_true(cpuid::feature_information::ecx::x2apic::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 21);
-//     this->expect_false(cpuid::feature_information::ecx::x2apic::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_movbe()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 22;
-//     this->expect_true(cpuid::feature_information::ecx::movbe::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 22);
-//     this->expect_false(cpuid::feature_information::ecx::movbe::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_popcnt()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 23;
-//     this->expect_true(cpuid::feature_information::ecx::popcnt::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 23);
-//     this->expect_false(cpuid::feature_information::ecx::popcnt::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_tsc_deadline()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 24;
-//     this->expect_true(cpuid::feature_information::ecx::tsc_deadline::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 24);
-//     this->expect_false(cpuid::feature_information::ecx::tsc_deadline::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_aesni()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 25;
-//     this->expect_true(cpuid::feature_information::ecx::aesni::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 25);
-//     this->expect_false(cpuid::feature_information::ecx::aesni::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_xsave()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 26;
-//     this->expect_true(cpuid::feature_information::ecx::xsave::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 26);
-//     this->expect_false(cpuid::feature_information::ecx::xsave::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_osxsave()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 27;
-//     this->expect_true(cpuid::feature_information::ecx::osxsave::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 27);
-//     this->expect_false(cpuid::feature_information::ecx::osxsave::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_avx()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 28;
-//     this->expect_true(cpuid::feature_information::ecx::avx::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 28);
-//     this->expect_false(cpuid::feature_information::ecx::avx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_f16c()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 29;
-//     this->expect_true(cpuid::feature_information::ecx::f16c::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 29);
-//     this->expect_false(cpuid::feature_information::ecx::f16c::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_rdrand()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 30;
-//     this->expect_true(cpuid::feature_information::ecx::rdrand::get());
-
-//     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 30);
-//     this->expect_false(cpuid::feature_information::ecx::rdrand::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dump()
-// {
-//     g_ecx_cpuid[cpuid::feature_information::addr] = 0xFFFFFFFFU;
-//     cpuid::feature_information::ecx::dump();
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_fsgsbase()
-// {
-//     g_regs.ebx = 0x1U << 0;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::fsgsbase::get());
-
-//     g_regs.ebx = ~(0x1U << 0);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::fsgsbase::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_ia32_tsc_adjust()
-// {
-//     g_regs.ebx = 0x1U << 1;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::ia32_tsc_adjust::get());
-
-//     g_regs.ebx = ~(0x1U << 1);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::ia32_tsc_adjust::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_sgx()
-// {
-//     g_regs.ebx = 0x1U << 2;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::sgx::get());
-
-//     g_regs.ebx = ~(0x1U << 2);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::sgx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_bmi1()
-// {
-//     g_regs.ebx = 0x1U << 3;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::bmi1::get());
-
-//     g_regs.ebx = ~(0x1U << 3);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::bmi1::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_hle()
-// {
-//     g_regs.ebx = 0x1U << 4;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::hle::get());
-
-//     g_regs.ebx = ~(0x1U << 4);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::hle::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_avx2()
-// {
-//     g_regs.ebx = 0x1U << 5;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::avx2::get());
-
-//     g_regs.ebx = ~(0x1U << 5);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::avx2::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_fdp_excptn_only()
-// {
-//     g_regs.ebx = 0x1U << 6;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::fdp_excptn_only::get());
-
-//     g_regs.ebx = ~(0x1U << 6);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::fdp_excptn_only::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_smep()
-// {
-//     g_regs.ebx = 0x1U << 7;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::smep::get());
-
-//     g_regs.ebx = ~(0x1U << 7);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::smep::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_bmi2()
-// {
-//     g_regs.ebx = 0x1U << 8;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::bmi2::get());
-
-//     g_regs.ebx = ~(0x1U << 8);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::bmi2::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_enhanced_rep()
-// {
-//     g_regs.ebx = 0x1U << 9;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::enhanced_rep::get());
-
-//     g_regs.ebx = ~(0x1U << 9);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::enhanced_rep::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_invpcid()
-// {
-//     g_regs.ebx = 0x1U << 10;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::invpcid::get());
-
-//     g_regs.ebx = ~(0x1U << 10);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::invpcid::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_rtm()
-// {
-//     g_regs.ebx = 0x1U << 11;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::rtm::get());
-
-//     g_regs.ebx = ~(0x1U << 11);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::rtm::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_rdt_m()
-// {
-//     g_regs.ebx = 0x1U << 12;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::rdt_m::get());
-
-//     g_regs.ebx = ~(0x1U << 12);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::rdt_m::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_depreciated_fpu_cs_ds()
-// {
-//     g_regs.ebx = 0x1U << 13;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::depreciated_fpu_cs_ds::get());
-
-//     g_regs.ebx = ~(0x1U << 13);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::depreciated_fpu_cs_ds::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_mpx()
-// {
-//     g_regs.ebx = 0x1U << 14;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::mpx::get());
-
-//     g_regs.ebx = ~(0x1U << 14);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::mpx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_rdt_a()
-// {
-//     g_regs.ebx = 0x1U << 15;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::rdt_a::get());
-
-//     g_regs.ebx = ~(0x1U << 15);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::rdt_a::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_rdseed()
-// {
-//     g_regs.ebx = 0x1U << 18;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::rdseed::get());
-
-//     g_regs.ebx = ~(0x1U << 18);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::rdseed::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_adx()
-// {
-//     g_regs.ebx = 0x1U << 19;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::adx::get());
-
-//     g_regs.ebx = ~(0x1U << 19);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::adx::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_smap()
-// {
-//     g_regs.ebx = 0x1U << 20;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::smap::get());
-
-//     g_regs.ebx = ~(0x1U << 20);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::smap::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_clflushopt()
-// {
-//     g_regs.ebx = 0x1U << 23;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::clflushopt::get());
-
-//     g_regs.ebx = ~(0x1U << 23);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::clflushopt::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_clwb()
-// {
-//     g_regs.ebx = 0x1U << 24;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::clwb::get());
-
-//     g_regs.ebx = ~(0x1U << 24);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::clwb::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_processor_trace()
-// {
-//     g_regs.ebx = 0x1U << 25;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::processor_trace::get());
-
-//     g_regs.ebx = ~(0x1U << 25);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::processor_trace::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_sha()
-// {
-//     g_regs.ebx = 0x1U << 29;
-//     this->expect_true(cpuid::extended_feature_flags::subleaf0::ebx::sha::get());
-
-//     g_regs.ebx = ~(0x1U << 29);
-//     this->expect_false(cpuid::extended_feature_flags::subleaf0::ebx::sha::get());
-// }
-
-// void
-// intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_dump()
-// {
-//     g_regs.ebx = 0xFFFFFFFFU;
-//     cpuid::extended_feature_flags::subleaf0::ebx::dump();
-// }
+static void
+setup_intrinsics(MockRepository &mocks)
+{
+    mocks.OnCallFunc(_cpuid_eax).Do(test_cpuid_eax);
+    mocks.OnCallFunc(_cpuid_ebx).Do(test_cpuid_ebx);
+    mocks.OnCallFunc(_cpuid_ecx).Do(test_cpuid_ecx);
+    mocks.OnCallFunc(_cpuid_edx).Do(test_cpuid_edx);
+    mocks.OnCallFunc(_cpuid).Do(test_cpuid);
+}
+
+TEST_CASE("intrinsics: cpuid_addr_size_phys")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000008ULL] = 0xFFFFFFFF;
+    CHECK(cpuid::addr_size::phys::get() == 0xFF);
+}
+
+TEST_CASE("intrinsics: cpuid_addr_size_linear")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000008ULL]= 0xFFFFFFFF;
+    CHECK(cpuid::addr_size::linear::get() == 0xFF);
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_sse3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 0;
+    CHECK(cpuid::feature_information::ecx::sse3::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::feature_information::ecx::sse3::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_pclmulqdq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 1;
+    CHECK(cpuid::feature_information::ecx::pclmulqdq::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::feature_information::ecx::pclmulqdq::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_dtes64")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 2;
+    CHECK(cpuid::feature_information::ecx::dtes64::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::feature_information::ecx::dtes64::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_monitor")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 3;
+    CHECK(cpuid::feature_information::ecx::monitor::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::feature_information::ecx::monitor::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_ds_cpl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 4;
+    CHECK(cpuid::feature_information::ecx::ds_cpl::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::feature_information::ecx::ds_cpl::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_vmx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 5;
+    CHECK(cpuid::feature_information::ecx::vmx::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::feature_information::ecx::vmx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_smx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 6;
+    CHECK(cpuid::feature_information::ecx::smx::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 6);
+    CHECK_FALSE(cpuid::feature_information::ecx::smx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_eist")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 7;
+    CHECK(cpuid::feature_information::ecx::eist::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 7);
+    CHECK_FALSE(cpuid::feature_information::ecx::eist::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_tm2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 8;
+    CHECK(cpuid::feature_information::ecx::tm2::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::feature_information::ecx::tm2::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_ssse3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 9;
+    CHECK(cpuid::feature_information::ecx::ssse3::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 9);
+    CHECK_FALSE(cpuid::feature_information::ecx::ssse3::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_cnxt_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 10;
+    CHECK(cpuid::feature_information::ecx::cnxt_id::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 10);
+    CHECK_FALSE(cpuid::feature_information::ecx::cnxt_id::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_sdbg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 11;
+    CHECK(cpuid::feature_information::ecx::sdbg::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 11);
+    CHECK_FALSE(cpuid::feature_information::ecx::sdbg::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_fma")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 12;
+    CHECK(cpuid::feature_information::ecx::fma::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 12);
+    CHECK_FALSE(cpuid::feature_information::ecx::fma::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_cmpxchg16b")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 13;
+    CHECK(cpuid::feature_information::ecx::cmpxchg16b::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 13);
+    CHECK_FALSE(cpuid::feature_information::ecx::cmpxchg16b::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_xtpr_update_control")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 14;
+    CHECK(cpuid::feature_information::ecx::xtpr_update_control::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 14);
+    CHECK_FALSE(cpuid::feature_information::ecx::xtpr_update_control::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_pdcm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 15;
+    CHECK(cpuid::feature_information::ecx::pdcm::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 15);
+    CHECK_FALSE(cpuid::feature_information::ecx::pdcm::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_pcid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 17;
+    CHECK(cpuid::feature_information::ecx::pcid::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 17);
+    CHECK_FALSE(cpuid::feature_information::ecx::pcid::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_dca")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 18;
+    CHECK(cpuid::feature_information::ecx::dca::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 18);
+    CHECK_FALSE(cpuid::feature_information::ecx::dca::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_sse41")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 19;
+    CHECK(cpuid::feature_information::ecx::sse41::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 19);
+    CHECK_FALSE(cpuid::feature_information::ecx::sse41::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_sse42")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 20;
+    CHECK(cpuid::feature_information::ecx::sse42::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 20);
+    CHECK_FALSE(cpuid::feature_information::ecx::sse42::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_x2apic")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 21;
+    CHECK(cpuid::feature_information::ecx::x2apic::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 21);
+    CHECK_FALSE(cpuid::feature_information::ecx::x2apic::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_movbe")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 22;
+    CHECK(cpuid::feature_information::ecx::movbe::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 22);
+    CHECK_FALSE(cpuid::feature_information::ecx::movbe::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_popcnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 23;
+    CHECK(cpuid::feature_information::ecx::popcnt::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 23);
+    CHECK_FALSE(cpuid::feature_information::ecx::popcnt::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_tsc_deadline")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 24;
+    CHECK(cpuid::feature_information::ecx::tsc_deadline::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 24);
+    CHECK_FALSE(cpuid::feature_information::ecx::tsc_deadline::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_aesni")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 25;
+    CHECK(cpuid::feature_information::ecx::aesni::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 25);
+    CHECK_FALSE(cpuid::feature_information::ecx::aesni::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_xsave")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 26;
+    CHECK(cpuid::feature_information::ecx::xsave::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 26);
+    CHECK_FALSE(cpuid::feature_information::ecx::xsave::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_osxsave")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 27;
+    CHECK(cpuid::feature_information::ecx::osxsave::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 27);
+    CHECK_FALSE(cpuid::feature_information::ecx::osxsave::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_avx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 28;
+    CHECK(cpuid::feature_information::ecx::avx::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 28);
+    CHECK_FALSE(cpuid::feature_information::ecx::avx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_f16c")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 29;
+    CHECK(cpuid::feature_information::ecx::f16c::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 29);
+    CHECK_FALSE(cpuid::feature_information::ecx::f16c::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_rdrand")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0x1UL << 30;
+    CHECK(cpuid::feature_information::ecx::rdrand::get());
+
+    g_ecx_cpuid[0x00000001ULL] = ~(0x1U << 30);
+    CHECK_FALSE(cpuid::feature_information::ecx::rdrand::get());
+}
+
+TEST_CASE("intrinsics: cpuid_feature_information_ecx_dump")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000001ULL] = 0xFFFFFFFFU;
+    cpuid::feature_information::ecx::dump();
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_eax_max_input")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000007ULL]= 0xFFFFFFFF;
+    CHECK(cpuid::extended_feature_flags::subleaf0::eax::max_input::get() == 0xFFFFFFFF);
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_fsgsbase")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 0;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::fsgsbase::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::fsgsbase::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_ia32_tsc_adjust")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 1;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::ia32_tsc_adjust::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::ia32_tsc_adjust::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_sgx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 2;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::sgx::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::sgx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_bmi1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 3;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::bmi1::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::bmi1::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_hle")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 4;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::hle::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::hle::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_avx2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 5;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::avx2::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::avx2::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_fdp_excptn_only")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 6;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::fdp_excptn_only::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 6);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::fdp_excptn_only::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_smep")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 7;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::smep::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 7);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::smep::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_bmi2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 8;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::bmi2::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::bmi2::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_movsb")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 9;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::movsb::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 9);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::movsb::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_invpcid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 10;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::invpcid::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 10);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::invpcid::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_rtm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 11;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::rtm::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 11);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::rtm::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_rtm_m")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 12;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::rtm_m::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 12);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::rtm_m::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_fpucs_fpuds")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 13;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::fpucs_fpuds::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 13);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::fpucs_fpuds::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_mpx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 14;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::mpx::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 14);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::mpx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_rdt_a")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 15;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::rdt_a::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 15);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::rdt_a::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_rdseed")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 18;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::rdseed::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 18);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::rdseed::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_adx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 19;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::adx::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 19);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::adx::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_smap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 20;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::smap::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 20);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::smap::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_clflushopt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 23;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::clflushopt::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 23);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::clflushopt::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_clwb")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 24;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::clwb::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 24);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::clwb::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_trace")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 25;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::trace::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 25);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::trace::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ebx_sha")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000007ULL] = 0x1UL << 29;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ebx::sha::get());
+
+    g_ebx_cpuid[0x00000007ULL] = ~(0x1U << 29);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ebx::sha::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_prefetchwt1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 0;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::prefetchwt1::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::prefetchwt1::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_umip")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 2;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::umip::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::umip::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_pku")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 3;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::pku::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::pku::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_ospke")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 4;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::ospke::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::ospke::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_mawau")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0xFFFFFFFFU;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::mawau::get() == 0x1F);
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_rdpid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 22;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::rdpid::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 22);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::rdpid::get());
+}
+
+TEST_CASE("intrinsics: cpuid_extended_feature_flags_subleaf0_ecx_sgx_lc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000007ULL] = 0x1UL << 30;
+    CHECK(cpuid::extended_feature_flags::subleaf0::ecx::sgx_lc::get());
+
+    g_ecx_cpuid[0x00000007ULL] = ~(0x1U << 30);
+    CHECK_FALSE(cpuid::extended_feature_flags::subleaf0::ecx::sgx_lc::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_eax_version_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000AULL] = 0x87654321ULL;
+    CHECK(cpuid::arch_perf_monitoring::eax::version_id::get() == 0x00000021ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_eax_gppmc_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000AULL] = 0x87654321ULL;
+    CHECK(cpuid::arch_perf_monitoring::eax::gppmc_count::get() == 0x00000043ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_eax_gppmc_bit_width")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000AULL] = 0x87654321ULL;
+    CHECK(cpuid::arch_perf_monitoring::eax::gppmc_bit_width::get() == 0x00000065ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_eax_ebx_enumeration_length")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000AULL] = 0x87654321ULL;
+    CHECK(cpuid::arch_perf_monitoring::eax::ebx_enumeration_length::get() == 0x00000087ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_core_cycle_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = 0x1U << 0;
+    CHECK(cpuid::arch_perf_monitoring::ebx::core_cycle_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::core_cycle_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_instr_retired_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 1);
+    CHECK(cpuid::arch_perf_monitoring::ebx::instr_retired_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::instr_retired_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_reference_cycles_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 2);
+    CHECK(cpuid::arch_perf_monitoring::ebx::reference_cycles_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::reference_cycles_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_llc_reference_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 3);
+    CHECK(cpuid::arch_perf_monitoring::ebx::llc_reference_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::llc_reference_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_llc_misses_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 4);
+    CHECK(cpuid::arch_perf_monitoring::ebx::llc_misses_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::llc_misses_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_branch_instr_retired_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 5);
+    CHECK(cpuid::arch_perf_monitoring::ebx::branch_instr_retired_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::branch_instr_retired_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_ebx_branch_mispredict_retired_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000AULL] = (0x1U << 6);
+    CHECK(cpuid::arch_perf_monitoring::ebx::branch_mispredict_retired_event::get());
+
+    g_ebx_cpuid[0x0000000AULL] = ~(0x1U << 6);
+    CHECK_FALSE(cpuid::arch_perf_monitoring::ebx::branch_mispredict_retired_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_edx_ffpmc_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000AULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::arch_perf_monitoring::edx::ffpmc_count::get() == 0x0000001FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_arch_perf_monitoring_edx_ffpmc_bit_width")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000AULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::arch_perf_monitoring::edx::ffpmc_bit_width::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_basic_cpuid_info_eax_max_input_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000000ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::basic_cpuid_info::eax::max_input_value::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_extend_cpuid_info_eax_max_input_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000000ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::extend_cpuid_info::eax::max_input_value::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_1_eax_part_1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_1::eax::part_1::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_1_ebx_part_2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x80000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_1::ebx::part_2::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_1_ecx_part_3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_1::ecx::part_3::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_1_edx_part_4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_1::edx::part_4::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_2_eax_part_1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000003ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_2::eax::part_1::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_2_ebx_part_2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x80000003ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_2::ebx::part_2::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_2_ecx_part_3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000003ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_2::ecx::part_3::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_2_edx_part_4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000003ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_2::edx::part_4::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_3_eax_part_1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x80000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_3::eax::part_1::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_3_ebx_part_2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x80000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_3::ebx::part_2::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_3_ecx_part_3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_3::ecx::part_3::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_processor_string_3_edx_part_4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::processor_string_3::edx::part_4::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_tlb_info_eax_info")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_tlb_info::eax::info::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_tlb_info_ebx_info")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_tlb_info::ebx::info::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_tlb_info_ecx_info")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_tlb_info::ecx::info::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_tlb_info_edx_info")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000002ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_tlb_info::edx::info::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_serial_num_ecx_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000003ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::serial_num::ecx::bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_serial_num_edx_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000003ULL]= 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::serial_num::edx::bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_cache_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::eax::cache_type::get() == 0x0000001FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_cache_level")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::eax::cache_level::get() == 0x00000007ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_self_init_level")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = (0x1U << 8);
+    CHECK(cpuid::intel::cache_parameters::eax::self_init_level::get());
+
+    g_eax_cpuid[0x00000004ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::intel::cache_parameters::eax::self_init_level::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_fully_associative")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = (0x1U << 9);
+    CHECK(cpuid::intel::cache_parameters::eax::fully_associative::get());
+
+    g_eax_cpuid[0x00000004ULL] = ~(0x1U << 9);
+    CHECK_FALSE(cpuid::intel::cache_parameters::eax::fully_associative::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_max_ids_logical")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::eax::max_ids_logical::get() == 0x00000FFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_eax_max_ids_physical")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::eax::max_ids_physical::get() == 0x0000003FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_ebx_l")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::ebx::l::get() == 0x00000FFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_ebx_p")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::ebx::p::get() == 0x000003FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_ebx_w")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::ebx::w::get() == 0x000003FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_ecx_num_sets")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000004ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::cache_parameters::ecx::num_sets::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_edx_wbinvd_invd")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000004ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::cache_parameters::edx::wbinvd_invd::get());
+
+    g_edx_cpuid[0x00000004ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::cache_parameters::edx::wbinvd_invd::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_edx_cache_inclusiveness")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000004ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::cache_parameters::edx::cache_inclusiveness::get());
+
+    g_edx_cpuid[0x00000004ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::cache_parameters::edx::cache_inclusiveness::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_cache_parameters_edx_complex_cache_indexing")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000004ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::cache_parameters::edx::complex_cache_indexing::get());
+
+    g_edx_cpuid[0x00000004ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::cache_parameters::edx::complex_cache_indexing::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_eax_min_line_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::eax::min_line_size::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_ebx_max_line_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::ebx::max_line_size::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_ecx_enum_mwait_extensions")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000005ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::monitor_mwait::ecx::enum_mwait_extensions::get());
+
+    g_ecx_cpuid[0x00000005ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::monitor_mwait::ecx::enum_mwait_extensions::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_ecx_interrupt_break_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000005ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::monitor_mwait::ecx::interrupt_break_event::get());
+
+    g_ecx_cpuid[0x00000005ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::monitor_mwait::ecx::interrupt_break_event::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c0::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c1::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c2::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c3::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c4::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c5::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c6::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_monitor_mwait_edx_num_c7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000005ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::monitor_mwait::edx::num_c7::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_temp_sensor")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::therm_power_management::eax::temp_sensor::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::temp_sensor::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_intel_turbo")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::therm_power_management::eax::intel_turbo::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::intel_turbo::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_arat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::therm_power_management::eax::arat::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::arat::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_pln")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 4);
+    CHECK(cpuid::intel::therm_power_management::eax::pln::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::pln::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_ecmd")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 5);
+    CHECK(cpuid::intel::therm_power_management::eax::ecmd::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::ecmd::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_ptm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 6);
+    CHECK(cpuid::intel::therm_power_management::eax::ptm::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 6);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::ptm::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hwp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 7);
+    CHECK(cpuid::intel::therm_power_management::eax::hwp::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 7);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hwp::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hwp_notification")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 8);
+    CHECK(cpuid::intel::therm_power_management::eax::hwp_notification::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hwp_notification::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hwp_activity_window")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 9);
+    CHECK(cpuid::intel::therm_power_management::eax::hwp_activity_window::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 9);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hwp_activity_window::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hwp_energy_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 10);
+    CHECK(cpuid::intel::therm_power_management::eax::hwp_energy_perf::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 10);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hwp_energy_perf::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hwp_package_request")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 11);
+    CHECK(cpuid::intel::therm_power_management::eax::hwp_package_request::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 11);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hwp_package_request::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_eax_hdc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000006ULL] = (0x1U << 13);
+    CHECK(cpuid::intel::therm_power_management::eax::hdc::get());
+
+    g_eax_cpuid[0x00000006ULL] = ~(0x1U << 13);
+    CHECK_FALSE(cpuid::intel::therm_power_management::eax::hdc::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_ebx_num_interrupts")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000006ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::therm_power_management::ebx::num_interrupts::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_ecx_hardware_feedback")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000006ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::therm_power_management::ecx::hardware_feedback::get());
+
+    g_ecx_cpuid[0x00000006ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::therm_power_management::ecx::hardware_feedback::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_therm_power_management_ecx_energy_perf_bias")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000006ULL] = (0x1U << 3);
+    CHECK(cpuid::intel::therm_power_management::ecx::energy_perf_bias::get());
+
+    g_ecx_cpuid[0x00000006ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::intel::therm_power_management::ecx::energy_perf_bias::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_access_cache_eax_ia32_platform_dca_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000009ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::access_cache::eax::ia32_platform_dca_cap::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_topology_enumeration_eax_x2apic_shift")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000BULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::topology_enumeration::eax::x2apic_shift::get() == 0x0000001FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_topology_enumeration_ebx_num_processors")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000BULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::topology_enumeration::ebx::num_processors::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_topology_enumeration_ecx_level_number")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000BULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::topology_enumeration::ecx::level_number::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_topology_enumeration_ecx_level_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000BULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::topology_enumeration::ecx::level_type::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_topology_enumeration_edx_x2apic_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000BULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::topology_enumeration::edx::x2apic_id::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_mainleaf_eax_supported_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::mainleaf::eax::supported_bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_mainleaf_ebx_max_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::mainleaf::ebx::max_size::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_mainleaf_ecx_max_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::mainleaf::ecx::max_size::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_mainleaf_edx_supported_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::mainleaf::edx::supported_bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_eax_xsaveopt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = (0x1U << 0);
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::eax::xsaveopt::get());
+
+    g_eax_cpuid[0x0000000DULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleaf0::eax::xsaveopt::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_eax_xsavec")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = (0x1U << 1);
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::eax::xsavec::get());
+
+    g_eax_cpuid[0x0000000DULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleaf0::eax::xsavec::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_eax_xgetbv")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = (0x1U << 2);
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::eax::xgetbv::get());
+
+    g_eax_cpuid[0x0000000DULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleaf0::eax::xgetbv::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_eax_xsaves_xrstors")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = (0x1U << 3);
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::eax::xsaves_xrstors::get());
+
+    g_eax_cpuid[0x0000000DULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleaf0::eax::xsaves_xrstors::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_ebx_xsave_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::ebx::xsave_size::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_ecx_supported_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::ecx::supported_bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleaf0_edx_supported_bits")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::subleaf0::edx::supported_bits::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleafn_eax_save_area_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::subleafn::eax::save_area_size::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleafn_ebx_save_area_offset")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000DULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::extended_state_enum::subleafn::ebx::save_area_offset::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleafn_ecx_n_supported")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000DULL] = (0x1U << 0);
+    CHECK(cpuid::intel::extended_state_enum::subleafn::ecx::n_supported::get());
+
+    g_ecx_cpuid[0x0000000DULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleafn::ecx::n_supported::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_extended_state_enum_subleafn_ecx_location")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000DULL] = (0x1U << 1);
+    CHECK(cpuid::intel::extended_state_enum::subleafn::ecx::location::get());
+
+    g_ecx_cpuid[0x0000000DULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::extended_state_enum::subleafn::ecx::location::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf0_ebx_rmid_max_range")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000FULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_rdt::subleaf0::ebx::rmid_max_range::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf0_edx_l3_rdt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000FULL] = (0x1U << 1);
+    CHECK(cpuid::intel::intel_rdt::subleaf0::edx::l3_rdt::get());
+
+    g_edx_cpuid[0x0000000FULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::intel_rdt::subleaf0::edx::l3_rdt::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf1_ebx_conversion_factor")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x0000000FULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_rdt::subleaf1::ebx::conversion_factor::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf1_ecx_rmid_max_range")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x0000000FULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_rdt::subleaf1::ecx::rmid_max_range::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf1_edx_l3_occupancy")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000FULL] = (0x1U << 0);
+    CHECK(cpuid::intel::intel_rdt::subleaf1::edx::l3_occupancy::get());
+
+    g_edx_cpuid[0x0000000FULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::intel_rdt::subleaf1::edx::l3_occupancy::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf1_edx_l3_total_bandwith")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000FULL] = (0x1U << 1);
+    CHECK(cpuid::intel::intel_rdt::subleaf1::edx::l3_total_bandwith::get());
+
+    g_edx_cpuid[0x0000000FULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::intel_rdt::subleaf1::edx::l3_total_bandwith::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_rdt_subleaf1_edx_l3_local_bandwith")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x0000000FULL] = (0x1U << 2);
+    CHECK(cpuid::intel::intel_rdt::subleaf1::edx::l3_local_bandwith::get());
+
+    g_edx_cpuid[0x0000000FULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::intel_rdt::subleaf1::edx::l3_local_bandwith::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf0_ebx_l3_cache")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000010ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::allocation_enumeration::subleaf0::ebx::l3_cache::get());
+
+    g_ebx_cpuid[0x00000010ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::allocation_enumeration::subleaf0::ebx::l3_cache::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf0_ebx_l2_cache")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000010ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::allocation_enumeration::subleaf0::ebx::l2_cache::get());
+
+    g_ebx_cpuid[0x00000010ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::allocation_enumeration::subleaf0::ebx::l2_cache::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf0_ebx_mem_bandwidth")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000010ULL] = (0x1U << 3);
+    CHECK(cpuid::intel::allocation_enumeration::subleaf0::ebx::mem_bandwidth::get());
+
+    g_ebx_cpuid[0x00000010ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::intel::allocation_enumeration::subleaf0::ebx::mem_bandwidth::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf1_eax_mask_length")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf1::eax::mask_length::get() == 0x0000001FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf1_ebx_map")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf1::ebx::map::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf1_ecx_data_prio")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000010ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::allocation_enumeration::subleaf1::ecx::data_prio::get());
+
+    g_ecx_cpuid[0x00000010ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::allocation_enumeration::subleaf1::ecx::data_prio::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf1_edx_max_cos")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf1::edx::max_cos::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf2_eax_mask_length")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf2::eax::mask_length::get() == 0x0000001FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf2_ebx_map")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf2::ebx::map::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf2_edx_max_cos")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf2::edx::max_cos::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf3_eax_max_throttle")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf3::eax::max_throttle::get() == 0x00000FFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf3_ecx_linear")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000010ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::allocation_enumeration::subleaf3::ecx::linear::get());
+
+    g_ecx_cpuid[0x00000010ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::allocation_enumeration::subleaf3::ecx::linear::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_allocation_enumeration_subleaf3_edx_max_cos")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000010ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::allocation_enumeration::subleaf3::edx::max_cos::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf0_eax_sgx1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000012ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::intel_sgx::subleaf0::eax::sgx1::get());
+
+    g_eax_cpuid[0x00000012ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::intel_sgx::subleaf0::eax::sgx1::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf0_eax_sgx2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000012ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::intel_sgx::subleaf0::eax::sgx2::get());
+
+    g_eax_cpuid[0x00000012ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::intel_sgx::subleaf0::eax::sgx2::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf0_ebx_miscselect")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf0::ebx::miscselect::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf0_edx_mes_not64")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf0::edx::mes_not64::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf0_edx_mes_64")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf0::edx::mes_64::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf1_part1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf1::part1::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf1_part2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf1::part2::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf1_part3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf1::part3::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf1_part4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf1::part4::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_eax_subleaf_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::eax::subleaf_type::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_eax_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::eax::address::get() == 0x000FFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_ebx_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::ebx::address::get() == 0x000FFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_ecx_epc_property")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::ecx::epc_property::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_ecx_epc_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::ecx::epc_size::get() == 0x000FFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_intel_sgx_subleaf2_edx_epc_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000012ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::intel_sgx::subleaf2::edx::epc_size::get() == 0x000FFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_eax_max_subleaf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000014ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::eax::max_subleaf::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_ia32_rtit_ctlcr3filter")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::ia32_rtit_ctlcr3filter::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::ia32_rtit_ctlcr3filter::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_configurable_psb")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::configurable_psb::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::configurable_psb::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_ip_filtering")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::ip_filtering::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::ip_filtering::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_mtc_timing_packet")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 3);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::mtc_timing_packet::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::mtc_timing_packet::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_ptwrite")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 4);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::ptwrite::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 4);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::ptwrite::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ebx_power_event_trace")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = (0x1U << 5);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ebx::power_event_trace::get());
+
+    g_ebx_cpuid[0x00000014ULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ebx::power_event_trace::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ecx_trading_enabled")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000014ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ecx::trading_enabled::get());
+
+    g_ecx_cpuid[0x00000014ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ecx::trading_enabled::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ecx_topa_entry")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000014ULL] = (0x1U << 1);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ecx::topa_entry::get());
+
+    g_ecx_cpuid[0x00000014ULL] = ~(0x1U << 1);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ecx::topa_entry::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ecx_single_range_output")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000014ULL] = (0x1U << 2);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ecx::single_range_output::get());
+
+    g_ecx_cpuid[0x00000014ULL] = ~(0x1U << 2);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ecx::single_range_output::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ecx_trace_transport")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000014ULL] = (0x1U << 3);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ecx::trace_transport::get());
+
+    g_ecx_cpuid[0x00000014ULL] = ~(0x1U << 3);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ecx::trace_transport::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_mainleaf_ecx_lip_values")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000014ULL] = (0x1U << 31);
+    CHECK(cpuid::intel::trace_enumeration::mainleaf::ecx::lip_values::get());
+
+    g_ecx_cpuid[0x00000014ULL] = ~(0x1U << 31);
+    CHECK_FALSE(cpuid::intel::trace_enumeration::mainleaf::ecx::lip_values::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_subleaf_eax_num_address_ranges")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000014ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::trace_enumeration::subleaf::eax::num_address_ranges::get() == 0x00000007ULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_subleaf_eax_bitmap_mtc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000014ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::trace_enumeration::subleaf::eax::bitmap_mtc::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_subleaf_ebx_bitmap_cycle_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::trace_enumeration::subleaf::ebx::bitmap_cycle_threshold::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_trace_enumeration_subleaf_ebx_bitmap_psb")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000014ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::trace_enumeration::subleaf::ebx::bitmap_psb::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_time_stamp_count_eax_tsc_denom")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000015ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::time_stamp_count::eax::tsc_denom::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_time_stamp_count_ebx_tsc_numer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000015ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::time_stamp_count::ebx::tsc_numer::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_time_stamp_count_ecx_nominal_freq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000015ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::time_stamp_count::ecx::nominal_freq::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_processor_freq_eax_base_freq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000016ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::processor_freq::eax::base_freq::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_processor_freq_ebx_max_freq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000016ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::processor_freq::ebx::max_freq::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_processor_freq_ecx_bus_freq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000016ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::processor_freq::ecx::bus_freq::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_mainleaf_max_socid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::mainleaf::max_socid::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_mainleaf_ebx_soc_vendor")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::mainleaf::ebx::soc_vendor::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_mainleaf_ebx_is_vendor_scheme")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000017ULL] = (0x1U << 16);
+    CHECK(cpuid::intel::vendor_attribute::mainleaf::ebx::is_vendor_scheme::get());
+
+    g_ebx_cpuid[0x00000017ULL] = ~(0x1U << 16);
+    CHECK_FALSE(cpuid::intel::vendor_attribute::mainleaf::ebx::is_vendor_scheme::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_mainleaf_ecx_project_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::mainleaf::ecx::project_id::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_mainleaf_edx_stepping_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::mainleaf::edx::stepping_id::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_subleaf1_eax_brand_string")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_eax_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::subleaf1::eax::brand_string::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_subleaf1_ebx_brand_string")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ebx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::subleaf1::ebx::brand_string::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_subleaf1_ecx_brand_string")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::subleaf1::ecx::brand_string::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_vendor_attribute_subleaf1_edx_brand_string")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x00000017ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::vendor_attribute::subleaf1::edx::brand_string::get() == 0xFFFFFFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_ecx_lahf_sahf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000001ULL] = (0x1U << 0);
+    CHECK(cpuid::intel::ext_feature_info::ecx::lahf_sahf::get());
+
+    g_ecx_cpuid[0x80000001ULL] = ~(0x1U << 0);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::ecx::lahf_sahf::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_ecx_lzcnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000001ULL] = (0x1U << 5);
+    CHECK(cpuid::intel::ext_feature_info::ecx::lzcnt::get());
+
+    g_ecx_cpuid[0x80000001ULL] = ~(0x1U << 5);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::ecx::lzcnt::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_ecx_prefetchw")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000001ULL] = (0x1U << 8);
+    CHECK(cpuid::intel::ext_feature_info::ecx::prefetchw::get());
+
+    g_ecx_cpuid[0x80000001ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::ecx::prefetchw::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_edx_syscall_sysret")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000001ULL] = (0x1U << 11);
+    CHECK(cpuid::intel::ext_feature_info::edx::syscall_sysret::get());
+
+    g_edx_cpuid[0x80000001ULL] = ~(0x1U << 11);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::edx::syscall_sysret::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_edx_execute_disable_bit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000001ULL] = (0x1U << 20);
+    CHECK(cpuid::intel::ext_feature_info::edx::execute_disable_bit::get());
+
+    g_edx_cpuid[0x80000001ULL] = ~(0x1U << 20);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::edx::execute_disable_bit::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_edx_pages_avail")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000001ULL] = (0x1U << 26);
+    CHECK(cpuid::intel::ext_feature_info::edx::pages_avail::get());
+
+    g_edx_cpuid[0x80000001ULL] = ~(0x1U << 26);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::edx::pages_avail::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_edx_rdtscp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000001ULL] = (0x1U << 27);
+    CHECK(cpuid::intel::ext_feature_info::edx::rdtscp::get());
+
+    g_edx_cpuid[0x80000001ULL] = ~(0x1U << 27);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::edx::rdtscp::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_ext_feature_info_edx_intel_64")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000001ULL] = (0x1U << 29);
+    CHECK(cpuid::intel::ext_feature_info::edx::intel_64::get());
+
+    g_edx_cpuid[0x80000001ULL] = ~(0x1U << 29);
+    CHECK_FALSE(cpuid::intel::ext_feature_info::edx::intel_64::get());
+}
+
+TEST_CASE("intrinsics: cpuid_intel_l2_info_ecx_line_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000006ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::l2_info::ecx::line_size::get() == 0x000000FFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_l2_info_ecx_l2_associativity")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000006ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::l2_info::ecx::l2_associativity::get() == 0x0000000FULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_l2_info_ecx_cache_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_ecx_cpuid[0x80000006ULL] = 0xFFFFFFFFULL;
+    CHECK(cpuid::intel::l2_info::ecx::cache_size::get() == 0x0000FFFFULL);
+}
+
+TEST_CASE("intrinsics: cpuid_intel_invariant_tsc_edx_available")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_edx_cpuid[0x80000007ULL] = (0x1U << 8);
+    CHECK(cpuid::intel::invariant_tsc::edx::available::get());
+
+    g_edx_cpuid[0x80000007ULL] = ~(0x1U << 8);
+    CHECK_FALSE(cpuid::intel::invariant_tsc::edx::available::get());
+}
+
+#endif

--- a/src/intrinsics/tests/test_cpuid_x64.cpp
+++ b/src/intrinsics/tests/test_cpuid_x64.cpp
@@ -65,15 +65,6 @@ extern "C" uint32_t
 test_cpuid_edx(uint32_t val) noexcept
 { return g_edx_cpuid[val]; }
 
-extern "C" void
-test_cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
-{
-    *static_cast<cpuid::value_type *>(eax) = g_regs.eax;
-    *static_cast<cpuid::value_type *>(ebx) = g_regs.ebx;
-    *static_cast<cpuid::value_type *>(ecx) = g_regs.ecx;
-    *static_cast<cpuid::value_type *>(edx) = g_regs.edx;
-}
-
 static void
 setup_intrinsics(MockRepository &mocks)
 {
@@ -81,7 +72,6 @@ setup_intrinsics(MockRepository &mocks)
     mocks.OnCallFunc(_cpuid_ebx).Do(test_cpuid_ebx);
     mocks.OnCallFunc(_cpuid_ecx).Do(test_cpuid_ecx);
     mocks.OnCallFunc(_cpuid_edx).Do(test_cpuid_edx);
-    mocks.OnCallFunc(_cpuid).Do(test_cpuid);
 }
 
 TEST_CASE("intrinsics: cpuid_addr_size_phys")


### PR DESCRIPTION
Added CPUID instructions in `include/intrinsics/x86/common/cpuid/cpuid_x64.cpp` and `include/intrinsics/x86/intel/cpuid/cpuid_intel_x64.h`. Tests are located in `src/intrinsics/tests/test_cpuid_x64.cpp`.