### PR TITLE
Added MSR Functions

### DIFF
--- a/include/intrinsics/x86/common/msrs/msrs_x64.h
+++ b/include/intrinsics/x86/common/msrs/msrs_x64.h
@@ -64,9 +64,423 @@ namespace msrs
     template<typename A, class T> void set(A addr, T val) noexcept
     { _write_msr(gsl::narrow_cast<field_type>(addr), val); }
 
+    namespace ia32_p5_mc_addr
+    {
+        constexpr const auto addr = 0x00000000UL;
+        constexpr const auto name = "ia32_p5_mc_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_p5_mc_type
+    {
+        constexpr const auto addr = 0x00000001UL;
+        constexpr const auto name = "ia32_p5_mc_type";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_tsc
+    {
+        constexpr const auto addr = 0x00000010UL;
+        constexpr const auto name = "ia32_tsc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_apic_base
+    {
+        constexpr const auto addr = 0x0000001BUL;
+        constexpr const auto name = "ia32_apic_base";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace bsp_flag
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "bsp_flag";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace enable_x2apic
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "enable_x2apic";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace apic_global_enable
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "apic_global_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace apic_base
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFF000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "apic_base";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_mperf
+    {
+        constexpr const auto addr = 0x000000E7UL;
+        constexpr const auto name = "ia32_mperf";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace tsc_freq_clock_count
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "tsc_freq_clock_count";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_aperf
+    {
+        constexpr const auto addr = 0x000000E8UL;
+        constexpr const auto name = "ia32_aperf";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace actual_freq_clock_count
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "actual_freq_clock_count";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_mtrrcap
+    {
+        constexpr const auto addr = 0x000000FEUL;
+        constexpr const auto name = "ia32_mtrrcap";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace vcnt
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "vcnt";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace fixed_range_mtrr
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "fixed_range_mtrr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace wc
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "wc";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace smrr
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "smrr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_sysenter_cs
+    {
+        constexpr const auto addr = 0x00000174UL;
+        constexpr const auto name = "ia32_sysenter_cs";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace cs_selector
+        {
+            constexpr const auto mask = 0x000000000000FFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "cs_selector";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_sysenter_esp
+    {
+        constexpr const auto addr = 0x00000175UL;
+        constexpr const auto name = "ia32_sysenter_esp";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_sysenter_eip
+    {
+        constexpr const auto addr = 0x00000176UL;
+        constexpr const auto name = "ia32_sysenter_eip";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_mcg_cap
+    {
+        constexpr const auto addr = 0x00000179UL;
+        constexpr const auto name = "ia32_mcg_cap";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace count
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "count";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace mcg_ctl
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "mcg_ctl";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_ext
+        {
+            constexpr const auto mask = 0x0000000000000200ULL;
+            constexpr const auto from = 9;
+            constexpr const auto name = "mcg_ext";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_cmci
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "mcg_cmci";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_tes
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "mcg_tes";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_ext_cnt
+        {
+            constexpr const auto mask = 0x0000000000FF0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "mcg_ext_cnt";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace mcg_ser
+        {
+            constexpr const auto mask = 0x0000000001000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "mcg_ser";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_elog
+        {
+            constexpr const auto mask = 0x0000000004000000ULL;
+            constexpr const auto from = 26;
+            constexpr const auto name = "mcg_elog";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace mcg_lmce
+        {
+            constexpr const auto mask = 0x0000000008000000ULL;
+            constexpr const auto from = 27;
+            constexpr const auto name = "mcg_lmce";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_mcg_status
+    {
+        constexpr const auto addr = 0x0000017AUL;
+        constexpr const auto name = "ia32_mcg_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace ripv
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "ripv";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace eipv
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "eipv";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace mcip
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "mcip";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace lmce_s
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "lmce_s";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mcg_ctl
+    {
+        constexpr const auto addr = 0x0000017BUL;
+        constexpr const auto name = "ia32_mcg_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
     namespace ia32_pat
     {
-        constexpr const auto addr = 0x00000277U;
+        constexpr const auto addr = 0x00000277UL;
         constexpr const auto name = "ia32_pat";
 
         inline auto get() noexcept
@@ -248,7 +662,7 @@ namespace msrs
                 case 7: return pa7::get();
                 default:
                     throw std::runtime_error("unknown pat index");
-            };
+            }
         }
 
         template<typename V, class I,
@@ -268,10 +682,298 @@ namespace msrs
                 case 7: return pa7::get(value);
                 default:
                     throw std::runtime_error("unknown pat index");
-            };
+            }
         }
     }
 
+    namespace ia32_mc0_ctl
+    {
+        constexpr const auto addr = 0x00000400UL;
+        constexpr const auto name = "ia32_mc0_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc0_status
+    {
+        constexpr const auto addr = 0x00000401UL;
+        constexpr const auto name = "ia32_mc0_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc0_addr
+    {
+        constexpr const auto addr = 0x00000402UL;
+        constexpr const auto name = "ia32_mc0_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc0_misc
+    {
+        constexpr const auto addr = 0x00000403UL;
+        constexpr const auto name = "ia32_mc0_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc1_ctl
+    {
+        constexpr const auto addr = 0x00000404UL;
+        constexpr const auto name = "ia32_mc1_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc1_status
+    {
+        constexpr const auto addr = 0x00000405UL;
+        constexpr const auto name = "ia32_mc1_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc1_addr
+    {
+        constexpr const auto addr = 0x00000406UL;
+        constexpr const auto name = "ia32_mc1_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc1_misc
+    {
+        constexpr const auto addr = 0x00000407UL;
+        constexpr const auto name = "ia32_mc1_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc2_ctl
+    {
+        constexpr const auto addr = 0x00000408UL;
+        constexpr const auto name = "ia32_mc2_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc2_status
+    {
+        constexpr const auto addr = 0x00000409UL;
+        constexpr const auto name = "ia32_mc2_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc2_addr
+    {
+        constexpr const auto addr = 0x0000040AUL;
+        constexpr const auto name = "ia32_mc2_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc2_misc
+    {
+        constexpr const auto addr = 0x0000040BUL;
+        constexpr const auto name = "ia32_mc2_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc3_ctl
+    {
+        constexpr const auto addr = 0x0000040CUL;
+        constexpr const auto name = "ia32_mc3_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc3_status
+    {
+        constexpr const auto addr = 0x0000040DUL;
+        constexpr const auto name = "ia32_mc3_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc3_addr
+    {
+        constexpr const auto addr = 0x0000040EUL;
+        constexpr const auto name = "ia32_mc3_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc3_misc
+    {
+        constexpr const auto addr = 0x0000040FUL;
+        constexpr const auto name = "ia32_mc3_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc4_ctl
+    {
+        constexpr const auto addr = 0x00000410UL;
+        constexpr const auto name = "ia32_mc4_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc4_status
+    {
+        constexpr const auto addr = 0x00000411UL;
+        constexpr const auto name = "ia32_mc4_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc4_addr
+    {
+        constexpr const auto addr = 0x00000412UL;
+        constexpr const auto name = "ia32_mc4_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc4_misc
+    {
+        constexpr const auto addr = 0x00000413UL;
+        constexpr const auto name = "ia32_mc4_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc5_ctl
+    {
+        constexpr const auto addr = 0x00000414UL;
+        constexpr const auto name = "ia32_mc5_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc5_status
+    {
+        constexpr const auto addr = 0x00000415UL;
+        constexpr const auto name = "ia32_mc5_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc5_addr
+    {
+        constexpr const auto addr = 0x00000416UL;
+        constexpr const auto name = "ia32_mc5_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc5_misc
+    {
+        constexpr const auto addr = 0x00000417UL;
+        constexpr const auto name = "ia32_mc5_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_star
+    {
+        constexpr const auto addr = 0xC0000081UL;
+        constexpr const auto name = "ia32_fs_base";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_lstar
+    {
+        constexpr const auto addr = 0xC0000082UL;
+        constexpr const auto name = "ia32_lstar";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_fmask
+    {
+        constexpr const auto addr = 0xC0000084UL;
+        constexpr const auto name = "ia32_fmask";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_kernel_gs_base
+    {
+        constexpr const auto addr = 0xC0000102UL;
+        constexpr const auto name = "ia32_kernel_gs_base";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_tsc_aux
+    {
+        constexpr const auto addr = 0xC0000103UL;
+        constexpr const auto name = "ia32_tsc_aux";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace aux
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "aux";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
 }
 }
 

--- a/include/intrinsics/x86/intel/msrs/msrs_intel_x64.h
+++ b/include/intrinsics/x86/intel/msrs/msrs_intel_x64.h
@@ -43,9 +43,38 @@ namespace msrs
     template<typename A, class T> void set(A addr, T val) noexcept
     { _write_msr(gsl::narrow_cast<field_type>(addr), val); }
 
+
+    namespace ia32_monitor_filter_size
+    {
+        constexpr const auto addr = 0x00000006UL;
+        constexpr const auto name = "ia32_monitor_filter_size";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_platform_id
+    {
+        constexpr const auto addr = 0x00000017UL;
+        constexpr const auto name = "ia32_platform_id";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace platform_id
+        {
+            constexpr const auto mask = 0x001C000000000000ULL;
+            constexpr const auto from = 50;
+            constexpr const auto name = "platform_id";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
     namespace ia32_feature_control
     {
-        constexpr const auto addr = 0x0000003AU;
+        constexpr const auto addr = 0x0000003AUL;
         constexpr const auto name = "ia32_feature_control";
 
         inline auto get() noexcept
@@ -93,11 +122,11 @@ namespace msrs
             { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
         }
 
-        namespace senter_local_function_enables
+        namespace senter_local_function_enable
         {
             constexpr const auto mask = 0x0000000000007F00ULL;
             constexpr const auto from = 8;
-            constexpr const auto name = "senter_local_function_enables";
+            constexpr const auto name = "senter_local_function_enable";
 
             inline auto get() noexcept
             { return get_bits(_read_msr(addr), mask) >> from; }
@@ -106,11 +135,11 @@ namespace msrs
             void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
         }
 
-        namespace senter_gloabl_function_enable
+        namespace senter_global_function_enables
         {
             constexpr const auto mask = 0x0000000000008000ULL;
             constexpr const auto from = 15;
-            constexpr const auto name = "senter_gloabl_function_enables";
+            constexpr const auto name = "senter_global_function_enables";
 
             inline auto get() noexcept
             { return get_bit(_read_msr(addr), from) != 0; }
@@ -157,44 +186,271 @@ namespace msrs
             inline void set(bool val) noexcept
             { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
         }
+    }
 
-        inline void dump() noexcept
+    namespace ia32_tsc_adjust
+    {
+        constexpr const auto addr = 0x0000003BUL;
+        constexpr const auto name = "ia32_tsc_adjust";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace thread_adjust
         {
-            bfdebug << "msrs::ia32_feature_control enabled flags:" << bfendl;
+            constexpr const auto mask = 0xFFFFFFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "thread_adjust";
 
-            if (lock_bit::get()) {
-                bfdebug << "    - " << lock_bit::name << bfendl;
-            }
-            if (enable_vmx_inside_smx::get()) {
-                bfdebug << "    - " << enable_vmx_inside_smx::name << bfendl;
-            }
-            if (enable_vmx_outside_smx::get()) {
-                bfdebug << "    - " << enable_vmx_outside_smx::name << bfendl;
-            }
-            if (senter_gloabl_function_enable::get()) {
-                bfdebug << "    - " << senter_gloabl_function_enable::name << bfendl;
-            }
-            if (sgx_launch_control_enable::get()) {
-                bfdebug << "    - " << sgx_launch_control_enable::name << bfendl;
-            }
-            if (sgx_global_enable::get()) {
-                bfdebug << "    - " << sgx_global_enable::name << bfendl;
-            }
-            if (lmce::get()) {
-                bfdebug << "    - " << lmce::name << bfendl;
-            }
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
 
-            bfdebug << bfendl;
-            bfdebug << "msrs::ia32_feature_control fields:" << bfendl;
-
-            bfdebug << "    - " << senter_local_function_enables::name << " = "
-                    << view_as_pointer(senter_local_function_enables::get()) << bfendl;
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
         }
+    }
+
+    namespace ia32_bios_updt_trig
+    {
+        constexpr const auto addr = 0x00000079UL;
+        constexpr const auto name = "ia32_bios_updt_trig";
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_bios_sign_id
+    {
+        constexpr const auto addr = 0x0000008BUL;
+        constexpr const auto name = "ia32_bios_sign_id";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace bios_sign_id
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "bios_sign_id";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_sgxlepubkeyhash0
+    {
+        constexpr const auto addr = 0x0000008CUL;
+        constexpr const auto name = "ia32_sgxlepubkeyhash0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_sgxlepubkeyhash1
+    {
+        constexpr const auto addr = 0x0000008DUL;
+        constexpr const auto name = "ia32_sgxlepubkeyhash1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_sgxlepubkeyhash2
+    {
+        constexpr const auto addr = 0x0000008EUL;
+        constexpr const auto name = "ia32_sgxlepubkeyhash2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_sgxlepubkeyhash3
+    {
+        constexpr const auto addr = 0x0000008FUL;
+        constexpr const auto name = "ia32_sgxlepubkeyhash3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_smm_monitor_ctl
+    {
+        constexpr const auto addr = 0x0000009BUL;
+        constexpr const auto name = "ia32_smm_monitor_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace valid
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "valid";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace vmxoff
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "vmxoff";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace mseg_base
+        {
+            constexpr const auto mask = 0x00000000FFFFF000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "mseg_base";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_smbase
+    {
+        constexpr const auto addr = 0x0000009EUL;
+        constexpr const auto name = "ia32_smbase";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_pmc0
+    {
+        constexpr const auto addr = 0x000000C1UL;
+        constexpr const auto name = "ia32_pmc0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc1
+    {
+        constexpr const auto addr = 0x000000C2UL;
+        constexpr const auto name = "ia32_pmc1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc2
+    {
+        constexpr const auto addr = 0x000000C3UL;
+        constexpr const auto name = "ia32_pmc2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc3
+    {
+        constexpr const auto addr = 0x000000C4UL;
+        constexpr const auto name = "ia32_pmc3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc4
+    {
+        constexpr const auto addr = 0x000000C5UL;
+        constexpr const auto name = "ia32_pmc4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc5
+    {
+        constexpr const auto addr = 0x000000C6UL;
+        constexpr const auto name = "ia32_pmc5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc6
+    {
+        constexpr const auto addr = 0x000000C7UL;
+        constexpr const auto name = "ia32_pmc6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pmc7
+    {
+        constexpr const auto addr = 0x000000C8UL;
+        constexpr const auto name = "ia32_pmc7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
     }
 
     namespace ia32_sysenter_cs
     {
-        constexpr const auto addr = 0x00000174U;
+        constexpr const auto addr = 0x00000174UL;
         constexpr const auto name = "ia32_sysenter_cs";
 
         inline auto get() noexcept
@@ -206,7 +462,7 @@ namespace msrs
 
     namespace ia32_sysenter_esp
     {
-        constexpr const auto addr = 0x00000175U;
+        constexpr const auto addr = 0x00000175UL;
         constexpr const auto name = "ia32_sysenter_esp";
 
         inline auto get() noexcept
@@ -228,9 +484,1117 @@ namespace msrs
         void set(T val) noexcept { _write_msr(addr, val); }
     }
 
+    namespace ia32_perfevtsel0
+    {
+        constexpr const auto addr = 0x00000186;
+        constexpr const auto name = "ia32_perfevtsel0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace event_select
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "event_select";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace umask
+        {
+            constexpr const auto mask = 0x000000000000FF00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "umask";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace usr
+        {
+            constexpr const auto mask = 0x0000000000010000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "usr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace os
+        {
+            constexpr const auto mask = 0x0000000000020000ULL;
+            constexpr const auto from = 17;
+            constexpr const auto name = "os";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace edge
+        {
+            constexpr const auto mask = 0x0000000000040000ULL;
+            constexpr const auto from = 18;
+            constexpr const auto name = "edge";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pc
+        {
+            constexpr const auto mask = 0x0000000000080000ULL;
+            constexpr const auto from = 19;
+            constexpr const auto name = "pc";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace interrupt
+        {
+            constexpr const auto mask = 0x0000000000100000ULL;
+            constexpr const auto from = 20;
+            constexpr const auto name = "interrupt";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace anythread
+        {
+            constexpr const auto mask = 0x0000000000200000ULL;
+            constexpr const auto from = 21;
+            constexpr const auto name = "anythread";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en
+        {
+            constexpr const auto mask = 0x0000000000400000ULL;
+            constexpr const auto from = 22;
+            constexpr const auto name = "en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace inv
+        {
+            constexpr const auto mask = 0x0000000000800000ULL;
+            constexpr const auto from = 23;
+            constexpr const auto name = "inv";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace cmask
+        {
+            constexpr const auto mask = 0x00000000FF000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "cmask";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_perfevtsel1
+    {
+        constexpr const auto addr = 0x00000187;
+        constexpr const auto name = "ia32_perfevtsel1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_perfevtsel2
+    {
+        constexpr const auto addr = 0x00000188;
+        constexpr const auto name = "ia32_perfevtsel2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_perfevtsel3
+    {
+        constexpr const auto addr = 0x00000189;
+        constexpr const auto name = "ia32_perfevtsel3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_perf_status
+    {
+        constexpr const auto addr = 0x00000198;
+        constexpr const auto name = "ia32_perf_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace state_value
+        {
+            constexpr const auto mask = 0x000000000000FFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "state_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_perf_ctl
+    {
+        constexpr const auto addr = 0x00000199;
+        constexpr const auto name = "ia32_perf_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace state_value
+        {
+            constexpr const auto mask = 0x000000000000FFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "state_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace ida_engage
+        {
+            constexpr const auto mask = 0x0000000100000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "ida_engage";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_clock_modulation
+    {
+        constexpr const auto addr = 0x0000019A;
+        constexpr const auto name = "ia32_clock_modulation";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace ext_duty_cycle
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "ext_duty_cycle";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace duty_cycle_values
+        {
+            constexpr const auto mask = 0x000000000000000EULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "duty_cycle_values";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace enable_modulation
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "enable_modulation";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_therm_interrupt
+    {
+        constexpr const auto addr = 0x0000019B;
+        constexpr const auto name = "ia32_therm_interrupt";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace high_temp
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "high_temp";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace low_temp
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "low_temp";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace prochot
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "prochot";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace forcepr
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "forcepr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace crit_temp
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "crit_temp";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace threshold_1_value
+        {
+            constexpr const auto mask = 0x0000000000007F00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "threshold_1_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace threshold_1_enable
+        {
+            constexpr const auto mask = 0x0000000000008000ULL;
+            constexpr const auto from = 15;
+            constexpr const auto name = "threshold_1_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace threshold_2_value
+        {
+            constexpr const auto mask = 0x00000000007F0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "threshold_2_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace threshold_2_enable
+        {
+            constexpr const auto mask = 0x0000000000800000ULL;
+            constexpr const auto from = 23;
+            constexpr const auto name = "threshold_2_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace power_limit
+        {
+            constexpr const auto mask = 0x0000000001000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "power_limit";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_therm_status
+    {
+        constexpr const auto addr = 0x0000019C;
+        constexpr const auto name = "ia32_therm_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace therm_status
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "therm_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace thermal_status_log
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "thermal_status_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace forcepr_event
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "forcepr_event";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace forcepr_log
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "forcepr_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace crit_temp_status
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "crit_temp_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace crit_temp_log
+        {
+            constexpr const auto mask = 0x0000000000000020ULL;
+            constexpr const auto from = 5;
+            constexpr const auto name = "crit_temp_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace therm_threshold1_status
+        {
+            constexpr const auto mask = 0x0000000000000040ULL;
+            constexpr const auto from = 6;
+            constexpr const auto name = "therm_threshold1_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace therm_threshold1_log
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "therm_threshold1_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace therm_threshold2_status
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "therm_threshold2_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace therm_threshold2_log
+        {
+            constexpr const auto mask = 0x0000000000000200ULL;
+            constexpr const auto from = 9;
+            constexpr const auto name = "therm_threshold2_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace power_limit_status
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "power_limit_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace power_limit_log
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "power_limit_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace current_limit_status
+        {
+            constexpr const auto mask = 0x0000000000001000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "current_limit_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace current_limit_log
+        {
+            constexpr const auto mask = 0x0000000000002000ULL;
+            constexpr const auto from = 13;
+            constexpr const auto name = "current_limit_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace cross_domain_status
+        {
+            constexpr const auto mask = 0x0000000000004000ULL;
+            constexpr const auto from = 14;
+            constexpr const auto name = "cross_domain_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace cross_domain_log
+        {
+            constexpr const auto mask = 0x0000000000008000ULL;
+            constexpr const auto from = 15;
+            constexpr const auto name = "cross_domain_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace digital_readout
+        {
+            constexpr const auto mask = 0x00000000007F0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "digital_readout";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace resolution_celcius
+        {
+            constexpr const auto mask = 0x0000000078000000ULL;
+            constexpr const auto from = 27;
+            constexpr const auto name = "resolution_celcius";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace reading_valid
+        {
+            constexpr const auto mask = 0x0000000080000000ULL;
+            constexpr const auto from = 31;
+            constexpr const auto name = "reading_valid";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_misc_enable
+    {
+        constexpr const auto addr = 0x000001A0UL;
+        constexpr const auto name = "ia32_misc_enable";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace fast_strings
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "fast_strings";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace auto_therm_control
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "auto_therm_control";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace perf_monitor
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "perf_monitor";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace branch_trace_storage
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "branch_trace_storage";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace processor_sampling
+        {
+            constexpr const auto mask = 0x0000000000001000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "processor_sampling";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace intel_speedstep
+        {
+            constexpr const auto mask = 0x0000000000010000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "intel_speedstep";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace monitor_fsm
+        {
+            constexpr const auto mask = 0x0000000000040000ULL;
+            constexpr const auto from = 18;
+            constexpr const auto name = "monitor_fsm";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace limit_cpuid_maxval
+        {
+            constexpr const auto mask = 0x0000000000400000ULL;
+            constexpr const auto from = 22;
+            constexpr const auto name = "limit_cpuid_maxval";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace xtpr_message
+        {
+            constexpr const auto mask = 0x0000000000800000ULL;
+            constexpr const auto from = 23;
+            constexpr const auto name = "xtpr_message";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace xd_bit
+        {
+            constexpr const auto mask = 0x0000000400000000ULL;
+            constexpr const auto from = 34;
+            constexpr const auto name = "xd_bit";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_energy_perf_bias
+    {
+        constexpr const auto addr = 0x000001B0UL;
+        constexpr const auto name = "ia32_energy_perf_bias";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace power_policy
+        {
+            constexpr const auto mask = 0x000000000000000FULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "power_policy";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_package_therm_status
+    {
+        constexpr const auto addr = 0x000001B1UL;
+        constexpr const auto name = "ia32_package_therm_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace pkg_therm_status
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "pkg_therm_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_therm_log
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "pkg_therm_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_prochot_event
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "pkg_prochot_event";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_prochot_log
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "pkg_prochot_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_crit_temp_status
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "pkg_crit_temp_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_crit_temp_log
+        {
+            constexpr const auto mask = 0x0000000000000020ULL;
+            constexpr const auto from = 5;
+            constexpr const auto name = "pkg_crit_temp_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_therm_thresh1_status
+        {
+            constexpr const auto mask = 0x0000000000000040ULL;
+            constexpr const auto from = 6;
+            constexpr const auto name = "pkg_therm_thresh1_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_therm_thresh1_log
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "pkg_therm_thresh1_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_therm_thresh2_status
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "pkg_therm_thresh2_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_therm_thresh2_log
+        {
+            constexpr const auto mask = 0x0000000000000200ULL;
+            constexpr const auto from = 9;
+            constexpr const auto name = "pkg_therm_thresh2_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_power_limit_status
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "pkg_power_limit_status";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pkg_power_limit_log
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "pkg_power_limit_log";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_digital_readout
+        {
+            constexpr const auto mask = 0x00000000007F0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "pkg_digital_readout";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_package_therm_interrupt
+    {
+        constexpr const auto addr = 0x000001B2UL;
+        constexpr const auto name = "ia32_energy_perf_bias";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace pkg_high_temp
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "pkg_high_temp";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_low_temp
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "pkg_low_temp";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_prochot
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "pkg_prochot";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_overheat
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "pkg_overheat";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_threshold_1_value
+        {
+            constexpr const auto mask = 0x0000000000007F00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "pkg_threshold_1_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace pkg_threshold_1_enable
+        {
+            constexpr const auto mask = 0x0000000000008000ULL;
+            constexpr const auto from = 15;
+            constexpr const auto name = "pkg_threshold_1_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_threshold_2_value
+        {
+            constexpr const auto mask = 0x00000000007F0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "pkg_threshold_2_value";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace pkg_threshold_2_enable
+        {
+            constexpr const auto mask = 0x0000000000800000ULL;
+            constexpr const auto from = 23;
+            constexpr const auto name = "pkg_threshold_2_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace pkg_power_limit
+        {
+            constexpr const auto mask = 0x0000000001000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "pkg_power_limit";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
     namespace ia32_debugctl
     {
-        constexpr const auto addr = 0x000001D9U;
+        constexpr const auto addr = 0x000001D9UL;
         constexpr const auto name = "ia32_debugctl";
 
         inline auto get() noexcept
@@ -451,9 +1815,2219 @@ namespace msrs
         }
     }
 
+    namespace ia32_smrr_physbase
+    {
+        constexpr const auto addr = 0x000001F2UL;
+        constexpr const auto name = "ia32_smrr_physbase";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace type
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "type";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace physbase
+        {
+            constexpr const auto mask = 0x00000000FFFFF000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "physbase";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_smrr_physmask
+    {
+        constexpr const auto addr = 0x000001F3UL;
+        constexpr const auto name = "ia32_smrr_physmask";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace valid
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "valid";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace physmask
+        {
+            constexpr const auto mask = 0x00000000FFFFF000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "physmask";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_platform_dca_cap
+    {
+        constexpr const auto addr = 0x000001F8UL;
+        constexpr const auto name = "ia32_platform_dca_cap";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_cpu_dca_cap
+    {
+        constexpr const auto addr = 0x000001F9UL;
+        constexpr const auto name = "ia32_cpu_dca_cap";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_dca_0_cap
+    {
+        constexpr const auto addr = 0x000001FAUL;
+        constexpr const auto name = "ia32_dca_0_cap";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace dca_active
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "dca_active";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace transaction
+        {
+            constexpr const auto mask = 0x0000000000000006ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "transaction";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace dca_type
+        {
+            constexpr const auto mask = 0x0000000000000078ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "dca_type";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace dca_queue_size
+        {
+            constexpr const auto mask = 0x0000000000000780ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "dca_queue_size";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace dca_delay
+        {
+            constexpr const auto mask = 0x000000000001E000ULL;
+            constexpr const auto from = 13;
+            constexpr const auto name = "dca_delay";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace sw_block
+        {
+            constexpr const auto mask = 0x0000000001000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "sw_block";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace hw_block
+        {
+            constexpr const auto mask = 0x0000000004000000ULL;
+            constexpr const auto from = 26;
+            constexpr const auto name = "hw_block";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mtrr_physbase0
+    {
+        constexpr const auto addr = 0x00000200UL;
+        constexpr const auto name = "ia32_mtrr_physbase0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask0
+    {
+        constexpr const auto addr = 0x00000201UL;
+        constexpr const auto name = "ia32_mtrr_physmask0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase1
+    {
+        constexpr const auto addr = 0x00000202UL;
+        constexpr const auto name = "ia32_mtrr_physbase1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask1
+    {
+        constexpr const auto addr = 0x00000203UL;
+        constexpr const auto name = "ia32_mtrr_physmask1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase2
+    {
+        constexpr const auto addr = 0x00000204UL;
+        constexpr const auto name = "ia32_mtrr_physbase2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask2
+    {
+        constexpr const auto addr = 0x00000205UL;
+        constexpr const auto name = "ia32_mtrr_physmask2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase3
+    {
+        constexpr const auto addr = 0x00000206UL;
+        constexpr const auto name = "ia32_mtrr_physbase3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask3
+    {
+        constexpr const auto addr = 0x00000207UL;
+        constexpr const auto name = "ia32_mtrr_physmask3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase4
+    {
+        constexpr const auto addr = 0x00000208UL;
+        constexpr const auto name = "ia32_mtrr_physbase4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask4
+    {
+        constexpr const auto addr = 0x00000209UL;
+        constexpr const auto name = "ia32_mtrr_physmask4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase5
+    {
+        constexpr const auto addr = 0x0000020AUL;
+        constexpr const auto name = "ia32_mtrr_physbase5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask5
+    {
+        constexpr const auto addr = 0x0000020BUL;
+        constexpr const auto name = "ia32_mtrr_physmask5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase6
+    {
+        constexpr const auto addr = 0x0000020CUL;
+        constexpr const auto name = "ia32_mtrr_physbase6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask6
+    {
+        constexpr const auto addr = 0x0000020DUL;
+        constexpr const auto name = "ia32_mtrr_physmask6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase7
+    {
+        constexpr const auto addr = 0x0000020EUL;
+        constexpr const auto name = "ia32_mtrr_physbase7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask7
+    {
+        constexpr const auto addr = 0x0000020FUL;
+        constexpr const auto name = "ia32_mtrr_physmask7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase8
+    {
+        constexpr const auto addr = 0x00000210UL;
+        constexpr const auto name = "ia32_mtrr_physbase8";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask8
+    {
+        constexpr const auto addr = 0x00000211UL;
+        constexpr const auto name = "ia32_mtrr_physmask8";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physbase9
+    {
+        constexpr const auto addr = 0x00000212UL;
+        constexpr const auto name = "ia32_mtrr_physbase9";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_physmask9
+    {
+        constexpr const auto addr = 0x00000213UL;
+        constexpr const auto name = "ia32_mtrr_physmask9";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix64k_00000
+    {
+        constexpr const auto addr = 0x00000250UL;
+        constexpr const auto name = "ia32_mtrr_fix64k_00000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix16k_80000
+    {
+        constexpr const auto addr = 0x00000258UL;
+        constexpr const auto name = "ia32_mtrr_fix16k_80000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix16k_A0000
+    {
+        constexpr const auto addr = 0x00000259UL;
+        constexpr const auto name = "ia32_mtrr_fix16k_A0000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_C0000
+    {
+        constexpr const auto addr = 0x00000268UL;
+        constexpr const auto name = "ia32_mtrr_fix4k_C0000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_C8000
+    {
+        constexpr const auto addr = 0x00000269UL;
+        constexpr const auto name = "ia32_mtrr_fix4k_C8000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_D0000
+    {
+        constexpr const auto addr = 0x0000026AUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_D0000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_D8000
+    {
+        constexpr const auto addr = 0x0000026BUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_D8000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_E0000
+    {
+        constexpr const auto addr = 0x0000026CUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_E0000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_E8000
+    {
+        constexpr const auto addr = 0x0000026DUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_E8000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_F0000
+    {
+        constexpr const auto addr = 0x0000026EUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_F0000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mtrr_fix4k_F8000
+    {
+        constexpr const auto addr = 0x0000026FUL;
+        constexpr const auto name = "ia32_mtrr_fix4k_F8000";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc0_ctl2
+    {
+        constexpr const auto addr = 0x00000280UL;
+        constexpr const auto name = "ia32_mc0_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc1_ctl2
+    {
+        constexpr const auto addr = 0x00000281UL;
+        constexpr const auto name = "ia32_mc1_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc2_ctl2
+    {
+        constexpr const auto addr = 0x00000282UL;
+        constexpr const auto name = "ia32_mc2_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc3_ctl2
+    {
+        constexpr const auto addr = 0x00000283UL;
+        constexpr const auto name = "ia32_mc3_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc4_ctl2
+    {
+        constexpr const auto addr = 0x00000284UL;
+        constexpr const auto name = "ia32_mc4_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc5_ctl2
+    {
+        constexpr const auto addr = 0x00000285UL;
+        constexpr const auto name = "ia32_mc5_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc6_ctl2
+    {
+        constexpr const auto addr = 0x00000286UL;
+        constexpr const auto name = "ia32_mc6_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc7_ctl2
+    {
+        constexpr const auto addr = 0x00000287UL;
+        constexpr const auto name = "ia32_mc7_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc8_ctl2
+    {
+        constexpr const auto addr = 0x00000288UL;
+        constexpr const auto name = "ia32_mc8_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc9_ctl2
+    {
+        constexpr const auto addr = 0x00000289UL;
+        constexpr const auto name = "ia32_mc9_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc10_ctl2
+    {
+        constexpr const auto addr = 0x0000028AUL;
+        constexpr const auto name = "ia32_mc10_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc11_ctl2
+    {
+        constexpr const auto addr = 0x0000028BUL;
+        constexpr const auto name = "ia32_mc11_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc12_ctl2
+    {
+        constexpr const auto addr = 0x0000028CUL;
+        constexpr const auto name = "ia32_mc12_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc13_ctl2
+    {
+        constexpr const auto addr = 0x0000028DUL;
+        constexpr const auto name = "ia32_mc13_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc14_ctl2
+    {
+        constexpr const auto addr = 0x0000028EUL;
+        constexpr const auto name = "ia32_mc14_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc15_ctl2
+    {
+        constexpr const auto addr = 0x0000028FUL;
+        constexpr const auto name = "ia32_mc15_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc16_ctl2
+    {
+        constexpr const auto addr = 0x00000290UL;
+        constexpr const auto name = "ia32_mc16_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc17_ctl2
+    {
+        constexpr const auto addr = 0x00000291UL;
+        constexpr const auto name = "ia32_mc17_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc18_ctl2
+    {
+        constexpr const auto addr = 0x00000292UL;
+        constexpr const auto name = "ia32_mc18_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc19_ctl2
+    {
+        constexpr const auto addr = 0x00000293UL;
+        constexpr const auto name = "ia32_mc19_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc20_ctl2
+    {
+        constexpr const auto addr = 0x00000294UL;
+        constexpr const auto name = "ia32_mc20_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc21_ctl2
+    {
+        constexpr const auto addr = 0x00000295UL;
+        constexpr const auto name = "ia32_mc21_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc22_ctl2
+    {
+        constexpr const auto addr = 0x00000296UL;
+        constexpr const auto name = "ia32_mc22_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc23_ctl2
+    {
+        constexpr const auto addr = 0x00000297UL;
+        constexpr const auto name = "ia32_mc23_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc24_ctl2
+    {
+        constexpr const auto addr = 0x00000298UL;
+        constexpr const auto name = "ia32_mc24_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc25_ctl2
+    {
+        constexpr const auto addr = 0x00000299UL;
+        constexpr const auto name = "ia32_mc25_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc26_ctl2
+    {
+        constexpr const auto addr = 0x0000029AUL;
+        constexpr const auto name = "ia32_mc26_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc27_ctl2
+    {
+        constexpr const auto addr = 0x0000029BUL;
+        constexpr const auto name = "ia32_mc27_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc28_ctl2
+    {
+        constexpr const auto addr = 0x0000029CUL;
+        constexpr const auto name = "ia32_mc28_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc29_ctl2
+    {
+        constexpr const auto addr = 0x0000029DUL;
+        constexpr const auto name = "ia32_mc29_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc30_ctl2
+    {
+        constexpr const auto addr = 0x0000029EUL;
+        constexpr const auto name = "ia32_mc30_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc31_ctl2
+    {
+        constexpr const auto addr = 0x0000029FUL;
+        constexpr const auto name = "ia32_mc31_ctl2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace error_threshold
+        {
+            constexpr const auto mask = 0x0000000000007FFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "error_threshold";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cmci_en
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "cmci_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mtrr_def_type
+    {
+        constexpr const auto addr = 0x000002FFUL;
+        constexpr const auto name = "ia32_mtrr_def_type";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace def_mem_type
+        {
+            constexpr const auto mask = 0x0000000000000007ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "def_mem_type";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace fixed_range_mtrr
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "fixed_range_mtrr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace mtrr
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "mtrr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_fixed_ctr0
+    {
+        constexpr const auto addr = 0x00000309UL;
+        constexpr const auto name = "ia32_fixed_ctr0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_fixed_ctr1
+    {
+        constexpr const auto addr = 0x0000030AUL;
+        constexpr const auto name = "ia32_fixed_ctr1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_fixed_ctr2
+    {
+        constexpr const auto addr = 0x0000030BUL;
+        constexpr const auto name = "ia32_fixed_ctr2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_perf_capabilities
+    {
+        constexpr const auto addr = 0x00000345UL;
+        constexpr const auto name = "ia32_perf_capabilities";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace lbo_format
+        {
+            constexpr const auto mask = 0x000000000000003FULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "lbo_format";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace pebs_trap
+        {
+            constexpr const auto mask = 0x0000000000000040ULL;
+            constexpr const auto from = 6;
+            constexpr const auto name = "pebs_trap";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pebs_savearchregs
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "pebs_savearchregs";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pebs_record_format
+        {
+            constexpr const auto mask = 0x0000000000000F00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "pebs_record_format";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace freeze
+        {
+            constexpr const auto mask = 0x0000000000001000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "freeze";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace counter_width
+        {
+            constexpr const auto mask = 0x0000000000002000ULL;
+            constexpr const auto from = 13;
+            constexpr const auto name = "counter_width";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_fixed_ctr_ctrl
+    {
+        constexpr const auto addr = 0x0000038DUL;
+        constexpr const auto name = "ia32_fixed_ctr_ctrl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace en0_os
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "en0_os";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en0_usr
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "en0_usr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en0_anythread
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "en0_anythread";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en0_pmi
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "en0_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en1_os
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "en1_os";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en1_usr
+        {
+            constexpr const auto mask = 0x0000000000000020ULL;
+            constexpr const auto from = 5;
+            constexpr const auto name = "en1_usr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en1_anythread
+        {
+            constexpr const auto mask = 0x0000000000000040ULL;
+            constexpr const auto from = 6;
+            constexpr const auto name = "en1_anythread";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en1_pmi
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "en1_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en2_os
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "en2_os";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en2_usr
+        {
+            constexpr const auto mask = 0x0000000000000200ULL;
+            constexpr const auto from = 9;
+            constexpr const auto name = "en2_usr";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en2_anythread
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "en2_anythread";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace en2_pmi
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "en2_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_perf_global_status
+    {
+        constexpr const auto addr = 0x0000038EUL;
+        constexpr const auto name = "ia32_perf_global_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace ovf_pmc0
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "ovf_pmc0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_pmc1
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "ovf_pmc1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_pmc2
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "ovf_pmc2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_pmc3
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "ovf_pmc3";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixedctr0
+        {
+            constexpr const auto mask = 0x0000000100000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "ovf_fixedctr0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixedctr1
+        {
+            constexpr const auto mask = 0x0000000200000000ULL;
+            constexpr const auto from = 33;
+            constexpr const auto name = "ovf_fixedctr1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixedctr2
+        {
+            constexpr const auto mask = 0x0000000400000000ULL;
+            constexpr const auto from = 34;
+            constexpr const auto name = "ovf_fixedctr2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace trace_topa_pmi
+        {
+            constexpr const auto mask = 0x0080000000000000ULL;
+            constexpr const auto from = 55;
+            constexpr const auto name = "trace_topa_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace lbr_frz
+        {
+            constexpr const auto mask = 0x0400000000000000ULL;
+            constexpr const auto from = 58;
+            constexpr const auto name = "lbr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ctr_frz
+        {
+            constexpr const auto mask = 0x0800000000000000ULL;
+            constexpr const auto from = 59;
+            constexpr const auto name = "ctr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace asci
+        {
+            constexpr const auto mask = 0x1000000000000000ULL;
+            constexpr const auto from = 60;
+            constexpr const auto name = "asci";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_uncore
+        {
+            constexpr const auto mask = 0x2000000000000000ULL;
+            constexpr const auto from = 61;
+            constexpr const auto name = "ovf_uncore";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovfbuf
+        {
+            constexpr const auto mask = 0x4000000000000000ULL;
+            constexpr const auto from = 62;
+            constexpr const auto name = "ovfbuf";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace condchgd
+        {
+            constexpr const auto mask = 0x8000000000000000ULL;
+            constexpr const auto from = 63;
+            constexpr const auto name = "condchgd";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
     namespace ia32_perf_global_ctrl
     {
-        constexpr const auto addr = 0x0000038FU;
+        constexpr const auto addr = 0x0000038FUL;
         constexpr const auto name = "ia32_perf_global_ctrl";
 
         inline auto get() noexcept
@@ -645,9 +4219,1264 @@ namespace msrs
         }
     }
 
+    namespace ia32_perf_global_ovf_ctrl
+    {
+        constexpr const auto addr = 0x00000390UL;
+        constexpr const auto name = "ia32_perf_global_ovf_ctrl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace clear_ovf_pmc0
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "clear_ovf_pmc0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_pmc1
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "clear_ovf_pmc1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_pmc2
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "clear_ovf_pmc2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_fixed_ctr0
+        {
+            constexpr const auto mask = 0x0000000100000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "clear_ovf_fixed_ctr0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_fixed_ctr1
+        {
+            constexpr const auto mask = 0x0000000200000000ULL;
+            constexpr const auto from = 33;
+            constexpr const auto name = "clear_ovf_fixed_ctr1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_fixed_ctr2
+        {
+            constexpr const auto mask = 0x0000000400000000ULL;
+            constexpr const auto from = 34;
+            constexpr const auto name = "clear_ovf_fixed_ctr2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_trace_topa_pmi
+        {
+            constexpr const auto mask = 0x0080000000000000ULL;
+            constexpr const auto from = 55;
+            constexpr const auto name = "clear_trace_topa_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace lbr_frz
+        {
+            constexpr const auto mask = 0x0400000000000000ULL;
+            constexpr const auto from = 58;
+            constexpr const auto name = "lbr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ctr_frz
+        {
+            constexpr const auto mask = 0x0800000000000000ULL;
+            constexpr const auto from = 59;
+            constexpr const auto name = "ctr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovf_uncore
+        {
+            constexpr const auto mask = 0x2000000000000000ULL;
+            constexpr const auto from = 61;
+            constexpr const auto name = "clear_ovf_uncore";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_ovfbuf
+        {
+            constexpr const auto mask = 0x4000000000000000ULL;
+            constexpr const auto from = 62;
+            constexpr const auto name = "clear_ovfbuf";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace clear_condchgd
+        {
+            constexpr const auto mask = 0x8000000000000000ULL;
+            constexpr const auto from = 63;
+            constexpr const auto name = "clear_condchgd";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_perf_global_status_set
+    {
+        constexpr const auto addr = 0x00000391UL;
+        constexpr const auto name = "ia32_perf_global_status_set";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace ovf_pmc0
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "ovf_pmc0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_pmc1
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "ovf_pmc1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_pmc2
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "ovf_pmc2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixed_ctr0
+        {
+            constexpr const auto mask = 0x0000000100000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "ovf_fixed_ctr0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixed_ctr1
+        {
+            constexpr const auto mask = 0x0000000200000000ULL;
+            constexpr const auto from = 33;
+            constexpr const auto name = "ovf_fixed_ctr1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_fixed_ctr2
+        {
+            constexpr const auto mask = 0x0000000400000000ULL;
+            constexpr const auto from = 34;
+            constexpr const auto name = "ovf_fixed_ctr2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace trace_topa_pmi
+        {
+            constexpr const auto mask = 0x0080000000000000ULL;
+            constexpr const auto from = 55;
+            constexpr const auto name = "trace_topa_pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace lbr_frz
+        {
+            constexpr const auto mask = 0x0400000000000000ULL;
+            constexpr const auto from = 58;
+            constexpr const auto name = "lbr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ctr_frz
+        {
+            constexpr const auto mask = 0x0800000000000000ULL;
+            constexpr const auto from = 59;
+            constexpr const auto name = "ctr_frz";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovf_uncore
+        {
+            constexpr const auto mask = 0x2000000000000000ULL;
+            constexpr const auto from = 61;
+            constexpr const auto name = "ovf_uncore";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace ovfbuf
+        {
+            constexpr const auto mask = 0x4000000000000000ULL;
+            constexpr const auto from = 62;
+            constexpr const auto name = "clear_ovfbuf";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_perf_global_inuse
+    {
+        constexpr const auto addr = 0x00000392UL;
+        constexpr const auto name = "ia32_perf_global_inuse";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace perfevtsel0
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "perfevtsel0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace perfevtsel1
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "perfevtsel1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace perfevtsel2
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "perfevtsel2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace fixed_ctr0
+        {
+            constexpr const auto mask = 0x0000000100000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "fixed_ctr0";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace fixed_ctr1
+        {
+            constexpr const auto mask = 0x0000000200000000ULL;
+            constexpr const auto from = 33;
+            constexpr const auto name = "fixed_ctr1";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace fixed_ctr2
+        {
+            constexpr const auto mask = 0x0000000400000000ULL;
+            constexpr const auto from = 34;
+            constexpr const auto name = "fixed_ctr2";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace pmi
+        {
+            constexpr const auto mask = 0x8000000000000000ULL;
+            constexpr const auto from = 63;
+            constexpr const auto name = "pmi";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_pebs_enable
+    {
+        constexpr const auto addr = 0x000003F1UL;
+        constexpr const auto name = "ia32_pebs_enable";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace pebs
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "pebs";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_mc6_ctl
+    {
+        constexpr const auto addr = 0x00000418UL;
+        constexpr const auto name = "ia32_mc6_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc6_status
+    {
+        constexpr const auto addr = 0x00000419UL;
+        constexpr const auto name = "ia32_mc6_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc6_addr
+    {
+        constexpr const auto addr = 0x0000041AUL;
+        constexpr const auto name = "ia32_mc6_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc6_misc
+    {
+        constexpr const auto addr = 0x0000041BUL;
+        constexpr const auto name = "ia32_mc6_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc7_ctl
+    {
+        constexpr const auto addr = 0x0000041CUL;
+        constexpr const auto name = "ia32_mc7_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc7_status
+    {
+        constexpr const auto addr = 0x0000041DUL;
+        constexpr const auto name = "ia32_mc7_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc7_addr
+    {
+        constexpr const auto addr = 0x0000041EUL;
+        constexpr const auto name = "ia32_mc7_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc7_misc
+    {
+        constexpr const auto addr = 0x0000041FUL;
+        constexpr const auto name = "ia32_mc7_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc8_ctl
+    {
+        constexpr const auto addr = 0x00000420UL;
+        constexpr const auto name = "ia32_mc8_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc8_status
+    {
+        constexpr const auto addr = 0x00000421UL;
+        constexpr const auto name = "ia32_mc8_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc8_addr
+    {
+        constexpr const auto addr = 0x00000422UL;
+        constexpr const auto name = "ia32_mc8_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc8_misc
+    {
+        constexpr const auto addr = 0x00000423UL;
+        constexpr const auto name = "ia32_mc8_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc9_ctl
+    {
+        constexpr const auto addr = 0x00000424UL;
+        constexpr const auto name = "ia32_mc9_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc9_status
+    {
+        constexpr const auto addr = 0x00000425UL;
+        constexpr const auto name = "ia32_mc9_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc9_addr
+    {
+        constexpr const auto addr = 0x00000426UL;
+        constexpr const auto name = "ia32_mc9_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc9_misc
+    {
+        constexpr const auto addr = 0x00000427UL;
+        constexpr const auto name = "ia32_mc9_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc10_ctl
+    {
+        constexpr const auto addr = 0x00000428UL;
+        constexpr const auto name = "ia32_mc10_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc10_status
+    {
+        constexpr const auto addr = 0x00000429UL;
+        constexpr const auto name = "ia32_mc10_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc10_addr
+    {
+        constexpr const auto addr = 0x0000042AUL;
+        constexpr const auto name = "ia32_mc10_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc10_misc
+    {
+        constexpr const auto addr = 0x0000042BUL;
+        constexpr const auto name = "ia32_mc10_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc11_ctl
+    {
+        constexpr const auto addr = 0x0000042CUL;
+        constexpr const auto name = "ia32_mc11_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc11_status
+    {
+        constexpr const auto addr = 0x0000042DUL;
+        constexpr const auto name = "ia32_mc11_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc11_addr
+    {
+        constexpr const auto addr = 0x0000042EUL;
+        constexpr const auto name = "ia32_mc11_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc11_misc
+    {
+        constexpr const auto addr = 0x0000042FUL;
+        constexpr const auto name = "ia32_mc11_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc12_ctl
+    {
+        constexpr const auto addr = 0x00000430UL;
+        constexpr const auto name = "ia32_mc12_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc12_status
+    {
+        constexpr const auto addr = 0x00000431UL;
+        constexpr const auto name = "ia32_mc12_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc12_addr
+    {
+        constexpr const auto addr = 0x00000432UL;
+        constexpr const auto name = "ia32_mc12_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc12_misc
+    {
+        constexpr const auto addr = 0x00000433UL;
+        constexpr const auto name = "ia32_mc12_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc13_ctl
+    {
+        constexpr const auto addr = 0x00000434UL;
+        constexpr const auto name = "ia32_mc13_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc13_status
+    {
+        constexpr const auto addr = 0x00000435UL;
+        constexpr const auto name = "ia32_mc13_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc13_addr
+    {
+        constexpr const auto addr = 0x00000436UL;
+        constexpr const auto name = "ia32_mc13_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc13_misc
+    {
+        constexpr const auto addr = 0x00000437UL;
+        constexpr const auto name = "ia32_mc13_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc14_ctl
+    {
+        constexpr const auto addr = 0x00000438UL;
+        constexpr const auto name = "ia32_mc14_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc14_status
+    {
+        constexpr const auto addr = 0x00000439UL;
+        constexpr const auto name = "ia32_mc14_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc14_addr
+    {
+        constexpr const auto addr = 0x0000043AUL;
+        constexpr const auto name = "ia32_mc14_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc14_misc
+    {
+        constexpr const auto addr = 0x0000043BUL;
+        constexpr const auto name = "ia32_mc14_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc15_ctl
+    {
+        constexpr const auto addr = 0x0000043CUL;
+        constexpr const auto name = "ia32_mc15_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc15_status
+    {
+        constexpr const auto addr = 0x0000043DUL;
+        constexpr const auto name = "ia32_mc15_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc15_addr
+    {
+        constexpr const auto addr = 0x0000043EUL;
+        constexpr const auto name = "ia32_mc15_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc15_misc
+    {
+        constexpr const auto addr = 0x0000043FUL;
+        constexpr const auto name = "ia32_mc15_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc16_ctl
+    {
+        constexpr const auto addr = 0x00000440UL;
+        constexpr const auto name = "ia32_mc16_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc16_status
+    {
+        constexpr const auto addr = 0x00000441UL;
+        constexpr const auto name = "ia32_mc16_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc16_addr
+    {
+        constexpr const auto addr = 0x00000442UL;
+        constexpr const auto name = "ia32_mc16_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc16_misc
+    {
+        constexpr const auto addr = 0x00000443UL;
+        constexpr const auto name = "ia32_mc16_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc17_ctl
+    {
+        constexpr const auto addr = 0x00000444UL;
+        constexpr const auto name = "ia32_mc17_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc17_status
+    {
+        constexpr const auto addr = 0x00000445UL;
+        constexpr const auto name = "ia32_mc17_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc17_addr
+    {
+        constexpr const auto addr = 0x00000446UL;
+        constexpr const auto name = "ia32_mc17_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc17_misc
+    {
+        constexpr const auto addr = 0x00000447UL;
+        constexpr const auto name = "ia32_mc17_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc18_ctl
+    {
+        constexpr const auto addr = 0x00000448UL;
+        constexpr const auto name = "ia32_mc18_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc18_status
+    {
+        constexpr const auto addr = 0x00000449UL;
+        constexpr const auto name = "ia32_mc18_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc18_addr
+    {
+        constexpr const auto addr = 0x0000044AUL;
+        constexpr const auto name = "ia32_mc18_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc18_misc
+    {
+        constexpr const auto addr = 0x0000044BUL;
+        constexpr const auto name = "ia32_mc18_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc19_ctl
+    {
+        constexpr const auto addr = 0x0000044CUL;
+        constexpr const auto name = "ia32_mc19_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc19_status
+    {
+        constexpr const auto addr = 0x0000044DUL;
+        constexpr const auto name = "ia32_mc19_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc19_addr
+    {
+        constexpr const auto addr = 0x0000044EUL;
+        constexpr const auto name = "ia32_mc19_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc19_misc
+    {
+        constexpr const auto addr = 0x0000044FUL;
+        constexpr const auto name = "ia32_mc19_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc20_ctl
+    {
+        constexpr const auto addr = 0x00000450UL;
+        constexpr const auto name = "ia32_mc20_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc20_status
+    {
+        constexpr const auto addr = 0x00000451UL;
+        constexpr const auto name = "ia32_mc20_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc20_addr
+    {
+        constexpr const auto addr = 0x00000452UL;
+        constexpr const auto name = "ia32_mc20_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc20_misc
+    {
+        constexpr const auto addr = 0x00000453UL;
+        constexpr const auto name = "ia32_mc20_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc21_ctl
+    {
+        constexpr const auto addr = 0x00000454UL;
+        constexpr const auto name = "ia32_mc21_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc21_status
+    {
+        constexpr const auto addr = 0x00000455UL;
+        constexpr const auto name = "ia32_mc21_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc21_addr
+    {
+        constexpr const auto addr = 0x00000456UL;
+        constexpr const auto name = "ia32_mc21_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc21_misc
+    {
+        constexpr const auto addr = 0x00000457UL;
+        constexpr const auto name = "ia32_mc21_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc22_ctl
+    {
+        constexpr const auto addr = 0x00000458UL;
+        constexpr const auto name = "ia32_mc22_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc22_status
+    {
+        constexpr const auto addr = 0x00000459UL;
+        constexpr const auto name = "ia32_mc22_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc22_addr
+    {
+        constexpr const auto addr = 0x0000045AUL;
+        constexpr const auto name = "ia32_mc22_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc22_misc
+    {
+        constexpr const auto addr = 0x0000045BUL;
+        constexpr const auto name = "ia32_mc22_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc23_ctl
+    {
+        constexpr const auto addr = 0x0000045CUL;
+        constexpr const auto name = "ia32_mc23_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc23_status
+    {
+        constexpr const auto addr = 0x0000045DUL;
+        constexpr const auto name = "ia32_mc23_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc23_addr
+    {
+        constexpr const auto addr = 0x0000045EUL;
+        constexpr const auto name = "ia32_mc23_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc23_misc
+    {
+        constexpr const auto addr = 0x0000045FUL;
+        constexpr const auto name = "ia32_mc23_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc24_ctl
+    {
+        constexpr const auto addr = 0x00000460UL;
+        constexpr const auto name = "ia32_mc24_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc24_status
+    {
+        constexpr const auto addr = 0x00000461UL;
+        constexpr const auto name = "ia32_mc24_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc24_addr
+    {
+        constexpr const auto addr = 0x00000462UL;
+        constexpr const auto name = "ia32_mc24_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc24_misc
+    {
+        constexpr const auto addr = 0x00000463UL;
+        constexpr const auto name = "ia32_mc24_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc25_ctl
+    {
+        constexpr const auto addr = 0x00000464UL;
+        constexpr const auto name = "ia32_mc25_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc25_status
+    {
+        constexpr const auto addr = 0x00000465UL;
+        constexpr const auto name = "ia32_mc25_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc25_addr
+    {
+        constexpr const auto addr = 0x00000466UL;
+        constexpr const auto name = "ia32_mc25_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc25_misc
+    {
+        constexpr const auto addr = 0x00000467UL;
+        constexpr const auto name = "ia32_mc25_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc26_ctl
+    {
+        constexpr const auto addr = 0x00000468UL;
+        constexpr const auto name = "ia32_mc26_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc26_status
+    {
+        constexpr const auto addr = 0x00000469UL;
+        constexpr const auto name = "ia32_mc26_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc26_addr
+    {
+        constexpr const auto addr = 0x0000046AUL;
+        constexpr const auto name = "ia32_mc26_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc26_misc
+    {
+        constexpr const auto addr = 0x0000046BUL;
+        constexpr const auto name = "ia32_mc26_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc27_ctl
+    {
+        constexpr const auto addr = 0x0000046CUL;
+        constexpr const auto name = "ia32_mc27_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc27_status
+    {
+        constexpr const auto addr = 0x0000046DUL;
+        constexpr const auto name = "ia32_mc27_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc27_addr
+    {
+        constexpr const auto addr = 0x0000046EUL;
+        constexpr const auto name = "ia32_mc27_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc27_misc
+    {
+        constexpr const auto addr = 0x0000046FUL;
+        constexpr const auto name = "ia32_mc27_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc28_ctl
+    {
+        constexpr const auto addr = 0x00000470UL;
+        constexpr const auto name = "ia32_mc28_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc28_status
+    {
+        constexpr const auto addr = 0x00000471UL;
+        constexpr const auto name = "ia32_mc28_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc28_addr
+    {
+        constexpr const auto addr = 0x00000472UL;
+        constexpr const auto name = "ia32_mc28_addr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_mc28_misc
+    {
+        constexpr const auto addr = 0x00000473UL;
+        constexpr const auto name = "ia32_mc28_misc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
     namespace ia32_vmx_basic
     {
-        constexpr const auto addr = 0x00000480U;
+        constexpr const auto addr = 0x00000480UL;
         constexpr const auto name = "ia32_vmx_basic";
 
         inline auto get() noexcept
@@ -752,9 +5581,125 @@ namespace msrs
         }
     }
 
+    namespace ia32_vmx_pinbased_ctls
+    {
+        constexpr const auto addr = 0x00000481UL;
+        constexpr const auto name = "ia32_vmx_pinbased_ctls";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace allowed_0_settings
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "allowed_0_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace allowed_1_settings
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "allowed_1_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_vmx_procbased_ctls
+    {
+        constexpr const auto addr = 0x00000482UL;
+        constexpr const auto name = "ia32_vmx_procbased_ctls";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace allowed_0_settings
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "allowed_0_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace allowed_1_settings
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "allowed_1_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_vmx_exit_ctls
+    {
+        constexpr const auto addr = 0x00000483UL;
+        constexpr const auto name = "ia32_vmx_exit_ctls";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace allowed_0_settings
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "allowed_0_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace allowed_1_settings
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "allowed_1_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_vmx_entry_ctls
+    {
+        constexpr const auto addr = 0x00000484UL;
+        constexpr const auto name = "ia32_vmx_entry_ctls";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace allowed_0_settings
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "allowed_0_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace allowed_1_settings
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "allowed_1_settings";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
     namespace ia32_vmx_misc
     {
-        constexpr const auto addr = 0x00000485U;
+        constexpr const auto addr = 0x00000485UL;
         constexpr const auto name = "ia32_vmx_misc";
 
         inline auto get() noexcept
@@ -926,7 +5871,7 @@ namespace msrs
 
     namespace ia32_vmx_cr0_fixed0
     {
-        constexpr const auto addr = 0x00000486U;
+        constexpr const auto addr = 0x00000486UL;
         constexpr const auto name = "ia32_vmx_cr0_fixed0";
 
         inline auto get() noexcept
@@ -935,7 +5880,7 @@ namespace msrs
 
     namespace ia32_vmx_cr0_fixed1
     {
-        constexpr const auto addr = 0x00000487U;
+        constexpr const auto addr = 0x00000487UL;
         constexpr const auto name = "ia32_vmx_cr0_fixed1";
 
         inline auto get() noexcept
@@ -944,7 +5889,7 @@ namespace msrs
 
     namespace ia32_vmx_cr4_fixed0
     {
-        constexpr const auto addr = 0x00000488U;
+        constexpr const auto addr = 0x00000488UL;
         constexpr const auto name = "ia32_vmx_cr4_fixed0";
 
         inline auto get() noexcept
@@ -953,16 +5898,35 @@ namespace msrs
 
     namespace ia32_vmx_cr4_fixed1
     {
-        constexpr const auto addr = 0x00000489U;
+        constexpr const auto addr = 0x00000489UL;
         constexpr const auto name = "ia32_vmx_cr4_fixed1";
 
         inline auto get() noexcept
         { return _read_msr(addr); }
     }
 
+    namespace ia32_vmx_vmcs_enum
+    {
+        constexpr const auto addr = 0x0000048AUL;
+        constexpr const auto name = "ia32_vmx_vmcs_enum";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace highest_index
+        {
+            constexpr const auto mask = 0x00000000000003FEULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "highest_index";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
     namespace ia32_vmx_procbased_ctls2
     {
-        constexpr const auto addr = 0x0000048BU;
+        constexpr const auto addr = 0x0000048BUL;
         constexpr const auto name = "ia32_vmx_procbased_ctls2";
 
         inline auto get() noexcept
@@ -1466,7 +6430,7 @@ namespace msrs
 
     namespace ia32_vmx_ept_vpid_cap
     {
-        constexpr const auto addr = 0x0000048CU;
+        constexpr const auto addr = 0x0000048CUL;
         constexpr const auto name = "ia32_vmx_ept_vpid_cap";
 
         inline auto get() noexcept
@@ -1676,7 +6640,7 @@ namespace msrs
 
     namespace ia32_vmx_true_pinbased_ctls
     {
-        constexpr const auto addr = 0x0000048DU;
+        constexpr const auto addr = 0x0000048DUL;
         constexpr const auto name = "ia32_vmx_true_pinbased_ctls";
 
         inline auto get() noexcept
@@ -1830,7 +6794,7 @@ namespace msrs
 
     namespace ia32_vmx_true_procbased_ctls
     {
-        constexpr const auto addr = 0x0000048EU;
+        constexpr const auto addr = 0x0000048EUL;
         constexpr const auto name = "ia32_vmx_true_procbased_ctls";
 
         inline auto get() noexcept
@@ -2384,7 +7348,7 @@ namespace msrs
 
     namespace ia32_vmx_true_exit_ctls
     {
-        constexpr const auto addr = 0x0000048FU;
+        constexpr const auto addr = 0x0000048FUL;
         constexpr const auto name = "ia32_vmx_true_exit_ctls";
 
         inline auto get() noexcept
@@ -2663,7 +7627,7 @@ namespace msrs
 
     namespace ia32_vmx_true_entry_ctls
     {
-        constexpr const auto addr = 0x00000490U;
+        constexpr const auto addr = 0x00000490UL;
         constexpr const auto name = "ia32_vmx_true_entry_ctls";
 
         inline auto get() noexcept
@@ -2892,7 +7856,7 @@ namespace msrs
 
     namespace ia32_vmx_vmfunc
     {
-        constexpr const auto addr = 0x00000491U;
+        constexpr const auto addr = 0x00000491UL;
         constexpr const auto name = "ia32_vmx_vmfunc";
 
         inline auto get() noexcept
@@ -2909,9 +7873,1993 @@ namespace msrs
         }
     }
 
+    namespace ia32_a_pmc0
+    {
+        constexpr const auto addr = 0x000004C1UL;
+        constexpr const auto name = "ia32_a_pmc0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc1
+    {
+        constexpr const auto addr = 0x000004C2UL;
+        constexpr const auto name = "ia32_a_pmc1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc2
+    {
+        constexpr const auto addr = 0x000004C3UL;
+        constexpr const auto name = "ia32_a_pmc2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc3
+    {
+        constexpr const auto addr = 0x000004C4UL;
+        constexpr const auto name = "ia32_a_pmc3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc4
+    {
+        constexpr const auto addr = 0x000004C5UL;
+        constexpr const auto name = "ia32_a_pmc4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc5
+    {
+        constexpr const auto addr = 0x000004C6UL;
+        constexpr const auto name = "ia32_a_pmc5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc6
+    {
+        constexpr const auto addr = 0x000004C7UL;
+        constexpr const auto name = "ia32_a_pmc6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_a_pmc7
+    {
+        constexpr const auto addr = 0x000004C8UL;
+        constexpr const auto name = "ia32_a_pmc7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_mcg_ext_ctl
+    {
+        constexpr const auto addr = 0x000004D0UL;
+        constexpr const auto name = "ia32_mcg_ext_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace lmce_en
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "lmce_en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_sgx_svn_sinit
+    {
+        constexpr const auto addr = 0x00000500UL;
+        constexpr const auto name = "ia32_sgx_svn_sinit";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace lock
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "lock";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace sgx_svn_sinit
+        {
+            constexpr const auto mask = 0x0000000000FF0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "sgx_svn_sinit";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_rtit_output_base
+    {
+        constexpr const auto addr = 0x00000560UL;
+        constexpr const auto name = "ia32_rtit_output_base";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace base_phys_address
+        {
+            constexpr const auto mask = 0x7FFFFFFFFFFFFF80ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "base_phys_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_output_mask_ptrs
+    {
+        constexpr const auto addr = 0x00000561UL;
+        constexpr const auto name = "ia32_rtit_output_mask_ptrs";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace mask_table_offset
+        {
+            constexpr const auto mask = 0x00000000FFFFFF80ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "mask_table_offset";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace output_offset
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "output_offset";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_ctl
+    {
+        constexpr const auto addr = 0x00000570UL;
+        constexpr const auto name = "ia32_rtit_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace traceen
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "traceen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace cycen
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "cycen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace os
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "os";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace user
+        {
+            constexpr const auto mask = 0x0000000000000008ULL;
+            constexpr const auto from = 3;
+            constexpr const auto name = "user";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace fabricen
+        {
+            constexpr const auto mask = 0x0000000000000040ULL;
+            constexpr const auto from = 6;
+            constexpr const auto name = "fabricen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace cr3_filter
+        {
+            constexpr const auto mask = 0x0000000000000080ULL;
+            constexpr const auto from = 7;
+            constexpr const auto name = "cr3_filter";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace topa
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "topa";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace mtcen
+        {
+            constexpr const auto mask = 0x0000000000000200ULL;
+            constexpr const auto from = 9;
+            constexpr const auto name = "mtcen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace tscen
+        {
+            constexpr const auto mask = 0x0000000000000400ULL;
+            constexpr const auto from = 10;
+            constexpr const auto name = "tscen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace disretc
+        {
+            constexpr const auto mask = 0x0000000000000800ULL;
+            constexpr const auto from = 11;
+            constexpr const auto name = "disretc";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace branchen
+        {
+            constexpr const auto mask = 0x0000000000002000ULL;
+            constexpr const auto from = 13;
+            constexpr const auto name = "branchen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace mtcfreq
+        {
+            constexpr const auto mask = 0x000000000003C000ULL;
+            constexpr const auto from = 14;
+            constexpr const auto name = "mtcfreq";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cycthresh
+        {
+            constexpr const auto mask = 0x0000000000780000ULL;
+            constexpr const auto from = 19;
+            constexpr const auto name = "cycthresh";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace psbfreq
+        {
+            constexpr const auto mask = 0x000000000F000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "psbfreq";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace addr0_cfg
+        {
+            constexpr const auto mask = 0x0000000F00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "addr0_cfg";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace addr1_cfg
+        {
+            constexpr const auto mask = 0x000000F000000000ULL;
+            constexpr const auto from = 36;
+            constexpr const auto name = "addr1_cfg";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace addr2_cfg
+        {
+            constexpr const auto mask = 0x00000F0000000000ULL;
+            constexpr const auto from = 40;
+            constexpr const auto name = "addr2_cfg";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace addr3_cfg
+        {
+            constexpr const auto mask = 0x0000F00000000000ULL;
+            constexpr const auto from = 44;
+            constexpr const auto name = "addr3_cfg";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_status
+    {
+        constexpr const auto addr = 0x00000571UL;
+        constexpr const auto name = "ia32_rtit_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace filteren
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "filteren";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace contexen
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "contexen";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace triggeren
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "triggeren";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace error
+        {
+            constexpr const auto mask = 0x0000000000000010ULL;
+            constexpr const auto from = 4;
+            constexpr const auto name = "error";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace stopped
+        {
+            constexpr const auto mask = 0x0000000000000020ULL;
+            constexpr const auto from = 5;
+            constexpr const auto name = "stopped";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace packetbytecnt
+        {
+            constexpr const auto mask = 0x0001FFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "packetbytecnt";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_cr3_match
+    {
+        constexpr const auto addr = 0x00000572UL;
+        constexpr const auto name = "ia32_rtit_cr3_match";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace cr3
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFFFE0ULL;
+            constexpr const auto from = 5;
+            constexpr const auto name = "cr3";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr0_a
+    {
+        constexpr const auto addr = 0x00000580UL;
+        constexpr const auto name = "ia32_rtit_addr0_a";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr0_b
+    {
+        constexpr const auto addr = 0x00000581UL;
+        constexpr const auto name = "ia32_rtit_addr0_b";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr1_a
+    {
+        constexpr const auto addr = 0x00000582UL;
+        constexpr const auto name = "ia32_rtit_addr1_a";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr1_b
+    {
+        constexpr const auto addr = 0x00000583UL;
+        constexpr const auto name = "ia32_rtit_addr1_b";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr2_a
+    {
+        constexpr const auto addr = 0x00000584UL;
+        constexpr const auto name = "ia32_rtit_addr2_a";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr2_b
+    {
+        constexpr const auto addr = 0x00000585UL;
+        constexpr const auto name = "ia32_rtit_addr2_b";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr3_a
+    {
+        constexpr const auto addr = 0x00000586UL;
+        constexpr const auto name = "ia32_rtit_addr3_a";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_rtit_addr3_b
+    {
+        constexpr const auto addr = 0x00000587UL;
+        constexpr const auto name = "ia32_rtit_addr3_b";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace virtual_address
+        {
+            constexpr const auto mask = 0x0000FFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "virtual_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace signext_va
+        {
+            constexpr const auto mask = 0xFFFF000000000000ULL;
+            constexpr const auto from = 48;
+            constexpr const auto name = "signext_va";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_ds_area
+    {
+        constexpr const auto addr = 0x00000600UL;
+        constexpr const auto name = "ia32_ds_area";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_tsc_deadline
+    {
+        constexpr const auto addr = 0x000006E0UL;
+        constexpr const auto name = "ia32_tsc_deadline";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_pm_enable
+    {
+        constexpr const auto addr = 0x00000770UL;
+        constexpr const auto name = "ia32_pm_enable";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace hwp
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "sce";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_hwp_capabilities
+    {
+        constexpr const auto addr = 0x00000771UL;
+        constexpr const auto name = "ia32_hwp_capabilities";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace highest_perf
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "highest_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace guaranteed_perf
+        {
+            constexpr const auto mask = 0x000000000000FF00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "guaranteed_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace most_efficient_perf
+        {
+            constexpr const auto mask = 0x0000000000FF0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "most_efficient_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace lowest_perf
+        {
+            constexpr const auto mask = 0x00000000FF000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "lowest_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+    }
+
+    namespace ia32_hwp_request_pkg
+    {
+        constexpr const auto addr = 0x00000772UL;
+        constexpr const auto name = "ia32_hwp_request_pkg";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace min_perf
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "min_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace max_perf
+        {
+            constexpr const auto mask = 0x000000000000FF00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "max_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace desired_perf
+        {
+            constexpr const auto mask = 0x0000000000FF0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "desired_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace energy_perf_pref
+        {
+            constexpr const auto mask = 0x00000000FF000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "energy_perf_pref";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace activity_window
+        {
+            constexpr const auto mask = 0x000003FF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "activity_window";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_hwp_interrupt
+    {
+        constexpr const auto addr = 0x00000773UL;
+        constexpr const auto name = "ia32_hwp_interrupt";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace perf_change
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "perf_change";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace excursion_min
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "excursion_min";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_hwp_request
+    {
+        constexpr const auto addr = 0x00000774UL;
+        constexpr const auto name = "ia32_hwp_request";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace min_perf
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "min_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace max_perf
+        {
+            constexpr const auto mask = 0x000000000000FF00ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "max_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace desired_perf
+        {
+            constexpr const auto mask = 0x0000000000FF0000ULL;
+            constexpr const auto from = 16;
+            constexpr const auto name = "desired_perf";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace energy_perf_pref
+        {
+            constexpr const auto mask = 0x00000000FF000000ULL;
+            constexpr const auto from = 24;
+            constexpr const auto name = "energy_perf_pref";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace activity_window
+        {
+            constexpr const auto mask = 0x000003FF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "energy_perf_pref";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace package_control
+        {
+            constexpr const auto mask = 0x0000040000000000ULL;
+            constexpr const auto from = 42;
+            constexpr const auto name = "package_control";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_hwp_status
+    {
+        constexpr const auto addr = 0x00000777UL;
+        constexpr const auto name = "ia32_hwp_status";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace perf_change
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "perf_change";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace excursion_to_min
+        {
+            constexpr const auto mask = 0x0000000000000004ULL;
+            constexpr const auto from = 2;
+            constexpr const auto name = "excursion_to_min";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_x2apic_apicid
+    {
+        constexpr const auto addr = 0x00000802UL;
+        constexpr const auto name = "ia32_x2apic_apicid";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_version
+    {
+        constexpr const auto addr = 0x00000803UL;
+        constexpr const auto name = "ia32_x2apic_version";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tpr
+    {
+        constexpr const auto addr = 0x00000808UL;
+        constexpr const auto name = "ia32_x2apic_tpr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_ppr
+    {
+        constexpr const auto addr = 0x0000080AUL;
+        constexpr const auto name = "ia32_x2apic_ppr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_eoi
+    {
+        constexpr const auto addr = 0x0000080BUL;
+        constexpr const auto name = "ia32_x2apic_eoi";
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_ldr
+    {
+        constexpr const auto addr = 0x0000080DUL;
+        constexpr const auto name = "ia32_x2apic_ldr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_sivr
+    {
+        constexpr const auto addr = 0x0000080FUL;
+        constexpr const auto name = "ia32_x2apic_sivr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_isr0
+    {
+        constexpr const auto addr = 0x00000810UL;
+        constexpr const auto name = "ia32_x2apic_isr0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr1
+    {
+        constexpr const auto addr = 0x00000811UL;
+        constexpr const auto name = "ia32_x2apic_isr1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr2
+    {
+        constexpr const auto addr = 0x00000812UL;
+        constexpr const auto name = "ia32_x2apic_isr2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr3
+    {
+        constexpr const auto addr = 0x00000813UL;
+        constexpr const auto name = "ia32_x2apic_isr3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr4
+    {
+        constexpr const auto addr = 0x00000814UL;
+        constexpr const auto name = "ia32_x2apic_isr4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr5
+    {
+        constexpr const auto addr = 0x00000815UL;
+        constexpr const auto name = "ia32_x2apic_isr5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr6
+    {
+        constexpr const auto addr = 0x00000816UL;
+        constexpr const auto name = "ia32_x2apic_isr6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_isr7
+    {
+        constexpr const auto addr = 0x00000817UL;
+        constexpr const auto name = "ia32_x2apic_isr7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr0
+    {
+        constexpr const auto addr = 0x00000818UL;
+        constexpr const auto name = "ia32_x2apic_tmr0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr1
+    {
+        constexpr const auto addr = 0x00000819UL;
+        constexpr const auto name = "ia32_x2apic_tmr1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr2
+    {
+        constexpr const auto addr = 0x0000081AUL;
+        constexpr const auto name = "ia32_x2apic_tmr2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr3
+    {
+        constexpr const auto addr = 0x0000081BUL;
+        constexpr const auto name = "ia32_x2apic_tmr3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr4
+    {
+        constexpr const auto addr = 0x0000081CUL;
+        constexpr const auto name = "ia32_x2apic_tmr4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr5
+    {
+        constexpr const auto addr = 0x0000081DUL;
+        constexpr const auto name = "ia32_x2apic_tmr5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr6
+    {
+        constexpr const auto addr = 0x0000081EUL;
+        constexpr const auto name = "ia32_x2apic_tmr6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_tmr7
+    {
+        constexpr const auto addr = 0x0000081FUL;
+        constexpr const auto name = "ia32_x2apic_tmr7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr0
+    {
+        constexpr const auto addr = 0x00000820UL;
+        constexpr const auto name = "ia32_x2apic_irr0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr1
+    {
+        constexpr const auto addr = 0x00000821UL;
+        constexpr const auto name = "ia32_x2apic_irr1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr2
+    {
+        constexpr const auto addr = 0x00000822UL;
+        constexpr const auto name = "ia32_x2apic_irr2";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr3
+    {
+        constexpr const auto addr = 0x00000823UL;
+        constexpr const auto name = "ia32_x2apic_irr3";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr4
+    {
+        constexpr const auto addr = 0x00000824UL;
+        constexpr const auto name = "ia32_x2apic_irr4";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr5
+    {
+        constexpr const auto addr = 0x00000825UL;
+        constexpr const auto name = "ia32_x2apic_irr5";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr6
+    {
+        constexpr const auto addr = 0x00000826UL;
+        constexpr const auto name = "ia32_x2apic_irr6";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_irr7
+    {
+        constexpr const auto addr = 0x00000827UL;
+        constexpr const auto name = "ia32_x2apic_irr7";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_esr
+    {
+        constexpr const auto addr = 0x00000828UL;
+        constexpr const auto name = "ia32_x2apic_esr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_cmci
+    {
+        constexpr const auto addr = 0x0000082FUL;
+        constexpr const auto name = "ia32_x2apic_lvt_cmci";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_icr
+    {
+        constexpr const auto addr = 0x00000830UL;
+        constexpr const auto name = "ia32_x2apic_icr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_timer
+    {
+        constexpr const auto addr = 0x00000832UL;
+        constexpr const auto name = "ia32_x2apic_lvt_timer";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_thermal
+    {
+        constexpr const auto addr = 0x00000833UL;
+        constexpr const auto name = "ia32_x2apic_lvt_thermal";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_pmi
+    {
+        constexpr const auto addr = 0x00000834UL;
+        constexpr const auto name = "ia32_x2apic_lvt_pmi";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_lint0
+    {
+        constexpr const auto addr = 0x00000835UL;
+        constexpr const auto name = "ia32_x2apic_lvt_lint0";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_lint1
+    {
+        constexpr const auto addr = 0x00000836UL;
+        constexpr const auto name = "ia32_x2apic_lvt_lint1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_lvt_error
+    {
+        constexpr const auto addr = 0x00000837UL;
+        constexpr const auto name = "ia32_x2apic_lvt_error";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_init_count
+    {
+        constexpr const auto addr = 0x00000838UL;
+        constexpr const auto name = "ia32_x2apic_init_count";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_cur_count
+    {
+        constexpr const auto addr = 0x00000839UL;
+        constexpr const auto name = "ia32_x2apic_cur_count";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+    }
+
+    namespace ia32_x2apic_div_conf
+    {
+        constexpr const auto addr = 0x0000083EUL;
+        constexpr const auto name = "ia32_x2apic_div_conf";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_x2apic_self_ipi
+    {
+        constexpr const auto addr = 0x0000083FUL;
+        constexpr const auto name = "ia32_x2apic_self_ipi";
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+    }
+
+    namespace ia32_debug_interface
+    {
+        constexpr const auto addr = 0x00000C80UL;
+        constexpr const auto name = "ia32_debug_interface";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace enable
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace lock
+        {
+            constexpr const auto mask = 0x0000000040000000ULL;
+            constexpr const auto from = 30;
+            constexpr const auto name = "lock";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace debug_occurred
+        {
+            constexpr const auto mask = 0x0000000080000000ULL;
+            constexpr const auto from = 31;
+            constexpr const auto name = "debug_occurred";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_l3_qos_cfg
+    {
+        constexpr const auto addr = 0x00000C81UL;
+        constexpr const auto name = "ia32_l3_qos_cfg";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace enable
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_qm_evtsel
+    {
+        constexpr const auto addr = 0x00000C8DUL;
+        constexpr const auto name = "ia32_qm_evtsel";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace event_id
+        {
+            constexpr const auto mask = 0x00000000000000FFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "event_id";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace resource_monitoring_id
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "resource_monitoring_id";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_qm_ctr
+    {
+        constexpr const auto addr = 0x00000C8EUL;
+        constexpr const auto name = "ia32_qm_ctr";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace resource_monitored_data
+        {
+            constexpr const auto mask = 0x3FFFFFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "resource_monitored_data";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+        }
+
+        namespace unavailable
+        {
+            constexpr const auto mask = 0x4000000000000000ULL;
+            constexpr const auto from = 62;
+            constexpr const auto name = "unavailable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+
+        namespace error
+        {
+            constexpr const auto mask = 0x8000000000000000ULL;
+            constexpr const auto from = 63;
+            constexpr const auto name = "error";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+        }
+    }
+
+    namespace ia32_pqr_assoc
+    {
+        constexpr const auto addr = 0x00000C8FUL;
+        constexpr const auto name = "ia32_pqr_assoc";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace resource_monitoring_id
+        {
+            constexpr const auto mask = 0x00000000FFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "resource_monitoring_id";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+
+        namespace cos
+        {
+            constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+            constexpr const auto from = 32;
+            constexpr const auto name = "cos";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_bndcfgs
+    {
+        constexpr const auto addr = 0x00000D90UL;
+        constexpr const auto name = "ia32_bndcfgs";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace en
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "en";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace bndpreserve
+        {
+            constexpr const auto mask = 0x0000000000000002ULL;
+            constexpr const auto from = 1;
+            constexpr const auto name = "bndpreserve";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+
+        namespace base_address
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFF000ULL;
+            constexpr const auto from = 12;
+            constexpr const auto name = "base_address";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
+    namespace ia32_xss
+    {
+        constexpr const auto addr = 0x00000DA0UL;
+        constexpr const auto name = "ia32_xss";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace trace_packet
+        {
+            constexpr const auto mask = 0x0000000000000100ULL;
+            constexpr const auto from = 8;
+            constexpr const auto name = "trace_packet";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_pkg_hdc_ctl
+    {
+        constexpr const auto addr = 0x00000DB0UL;
+        constexpr const auto name = "ia32_pkg_hdc_ctl";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace hdc_pkg_enable
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "hdc_pkg_enable";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_pm_ctl1
+    {
+        constexpr const auto addr = 0x00000DB1UL;
+        constexpr const auto name = "ia32_pm_ctl1";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+        void set(T val) noexcept { _write_msr(addr, val); }
+
+        namespace hdc_allow_block
+        {
+            constexpr const auto mask = 0x0000000000000001ULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "hdc_allow_block";
+
+            inline auto get() noexcept
+            { return get_bit(_read_msr(addr), from) != 0; }
+
+            inline void set(bool val) noexcept
+            { _write_msr(addr, val ? set_bit(_read_msr(addr), from) : clear_bit(_read_msr(addr), from)); }
+        }
+    }
+
+    namespace ia32_thread_stall
+    {
+        constexpr const auto addr = 0x00000DB2UL;
+        constexpr const auto name = "ia32_thread_stall";
+
+        inline auto get() noexcept
+        { return _read_msr(addr); }
+
+        namespace stall_cycle_cnt
+        {
+            constexpr const auto mask = 0xFFFFFFFFFFFFFFFFULL;
+            constexpr const auto from = 0;
+            constexpr const auto name = "stall_cycle_cnt";
+
+            inline auto get() noexcept
+            { return get_bits(_read_msr(addr), mask) >> from; }
+
+            template<typename T, typename =  std::enable_if<std::is_integral<T>::value>>
+            void set(T val) noexcept { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+        }
+    }
+
     namespace ia32_efer
     {
-        constexpr const auto addr = 0xC0000080U;
+        constexpr const auto addr = 0xC0000080UL;
         constexpr const auto name = "ia32_efer";
 
         inline auto get() noexcept
@@ -3006,7 +9954,7 @@ namespace msrs
 
     namespace ia32_fs_base
     {
-        constexpr const auto addr = 0xC0000100U;
+        constexpr const auto addr = 0xC0000100UL;
         constexpr const auto name = "ia32_fs_base";
 
         inline auto get() noexcept
@@ -3018,7 +9966,7 @@ namespace msrs
 
     namespace ia32_gs_base
     {
-        constexpr const auto addr = 0xC0000101U;
+        constexpr const auto addr = 0xC0000101UL;
         constexpr const auto name = "ia32_gs_base";
 
         inline auto get() noexcept

--- a/include/intrinsics/x86/intel/vmcs/64bit_control_fields.h
+++ b/include/intrinsics/x86/intel/vmcs/64bit_control_fields.h
@@ -50,7 +50,7 @@ auto set_vm_function_control(bool val, MA msr_addr, CA ctls_addr,
     }
 
     if (val) {
-        auto allowed1 = (intel_x64::msrs::get(msr_addr) & mask) != 0;
+        auto allowed1 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & mask) != 0;
 
         if (!allowed1) {
             throw std::logic_error("set_vm_function_control failed: "_s + name
@@ -80,7 +80,7 @@ auto set_vm_function_control_if_allowed(bool val, MA msr_addr, CA ctls_addr,
     }
 
     if (val) {
-        auto allowed1 = (intel_x64::msrs::get(msr_addr) & mask) != 0;
+        auto allowed1 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & mask) != 0;
 
         if (!allowed1 && verbose) {
             bfwarning << "set_vm_function_control failed: " << name

--- a/include/intrinsics/x86/intel/vmcs/check_controls.h
+++ b/include/intrinsics/x86/intel/vmcs/check_controls.h
@@ -49,8 +49,8 @@ auto control_reserved_properly_set(MA msr_addr, C ctls, const char *ctls_name)
 {
     using namespace vmcs::primary_processor_based_vm_execution_controls;
 
-    auto allowed0 = (msrs::get(msr_addr) & 0x00000000FFFFFFFFULL);
-    auto allowed1 = ((msrs::get(msr_addr) >> 32) & 0x00000000FFFFFFFFULL);
+    auto allowed0 = (msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & 0x00000000FFFFFFFFULL);
+    auto allowed1 = ((msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) >> 32) & 0x00000000FFFFFFFFULL);
     auto allowed1_failed = false;
 
     ctls &= 0x00000000FFFFFFFFULL;

--- a/include/intrinsics/x86/intel/vmcs/helpers.h
+++ b/include/intrinsics/x86/intel/vmcs/helpers.h
@@ -102,7 +102,7 @@ auto set_vm_control(bool val, MA msr_addr, CA ctls_addr, const char *name, M mas
     }
 
     if (!val) {
-        auto is_allowed0 = (intel_x64::msrs::get(msr_addr) & mask) == 0;
+        auto is_allowed0 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & mask) == 0;
 
         if (!is_allowed0) {
             throw std::logic_error("set_vm_control failed: "_s + name + " control is not allowed to be cleared to 0");
@@ -110,7 +110,7 @@ auto set_vm_control(bool val, MA msr_addr, CA ctls_addr, const char *name, M mas
 
         intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) & ~mask), name);
     } else {
-        auto is_allowed1 = (intel_x64::msrs::get(msr_addr) & (mask << 32)) != 0;
+        auto is_allowed1 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & (mask << 32)) != 0;
 
         if (!is_allowed1) {
             throw std::logic_error("set_vm_control failed: "_s + name + " control is not allowed to be set to 1");
@@ -133,7 +133,7 @@ auto set_vm_control_if_allowed(bool val, MA msr_addr, CA ctls_addr, const char *
     }
 
     if (!val) {
-        auto is_allowed0 = (intel_x64::msrs::get(msr_addr) & mask) == 0;
+        auto is_allowed0 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & mask) == 0;
 
         if (is_allowed0) {
             intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) & ~mask), name);
@@ -144,7 +144,7 @@ auto set_vm_control_if_allowed(bool val, MA msr_addr, CA ctls_addr, const char *
             }
         }
     } else {
-        auto is_allowed1 = (intel_x64::msrs::get(msr_addr) & (mask << 32)) != 0;
+        auto is_allowed1 = (intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(msr_addr)) & (mask << 32)) != 0;
 
         if (is_allowed1) {
             intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) | mask), name);

--- a/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -284,7 +284,7 @@ exit_handler_intel_x64::handle_rdmsr()
             break;
 
         default:
-            msr = intel_x64::msrs::get(m_state_save->rcx);
+            msr = intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(m_state_save->rcx));
             break;
 
         // QUIRK:

--- a/src/intrinsics/tests/test_msrs_intel_x64.cpp
+++ b/src/intrinsics/tests/test_msrs_intel_x64.cpp
@@ -19,2359 +19,8701 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#define CATCH_CONFIG_MAIN
 #include <catch/catch.hpp>
+#include <intrinsics/x86/intel_x64.h>
+#include <hippomocks.h>
 
-TEST_CASE("test name goes here")
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+using namespace x64;
+
+std::map<msrs::field_type, msrs::value_type> g_msrs;
+
+extern "C" uint64_t
+test_read_msr(uint32_t addr) noexcept
+{ return g_msrs[addr]; }
+
+extern "C" void
+test_write_msr(uint32_t addr, uint64_t val) noexcept
+{ g_msrs[addr] = val; }
+
+static void
+setup_intrinsics(MockRepository &mocks)
 {
-    CHECK(true);
+    mocks.OnCallFunc(_read_msr).Do(test_read_msr);
+    mocks.OnCallFunc(_write_msr).Do(test_write_msr);
 }
 
-// #include <test.h>
-// #include <intrinsics/msrs_intel_x64.h>
-
-// using namespace intel_x64;
-
-// extern std::map<msrs::field_type, msrs::value_type> g_msrs;
-
-// void
-// intrinsics_ut::test_general_msr_access()
-// {
-//     msrs::set(0x1, 100UL);
-//     this->expect_true(msrs::get(0x1) == 100UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control()
-// {
-//     msrs::ia32_feature_control::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_feature_control::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_feature_control::dump();
-
-//     msrs::ia32_feature_control::set(0x0U);
-//     this->expect_true(msrs::ia32_feature_control::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_lock_bit()
-// {
-//     msrs::ia32_feature_control::lock_bit::set(true);
-//     this->expect_true(msrs::ia32_feature_control::lock_bit::get());
-
-//     msrs::ia32_feature_control::lock_bit::set(false);
-//     this->expect_false(msrs::ia32_feature_control::lock_bit::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_enable_vmx_inside_smx()
-// {
-//     msrs::ia32_feature_control::enable_vmx_inside_smx::set(true);
-//     this->expect_true(msrs::ia32_feature_control::enable_vmx_inside_smx::get());
-
-//     msrs::ia32_feature_control::enable_vmx_inside_smx::set(false);
-//     this->expect_false(msrs::ia32_feature_control::enable_vmx_inside_smx::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_enable_vmx_outside_smx()
-// {
-//     msrs::ia32_feature_control::enable_vmx_outside_smx::set(true);
-//     this->expect_true(msrs::ia32_feature_control::enable_vmx_outside_smx::get());
-
-//     msrs::ia32_feature_control::enable_vmx_outside_smx::set(false);
-//     this->expect_false(msrs::ia32_feature_control::enable_vmx_outside_smx::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_senter_local_function_enables()
-// {
-//     msrs::ia32_feature_control::senter_local_function_enables::set(6UL);
-//     this->expect_true(msrs::ia32_feature_control::senter_local_function_enables::get() == 6UL);
-
-//     msrs::ia32_feature_control::senter_local_function_enables::set(4UL);
-//     this->expect_true(msrs::ia32_feature_control::senter_local_function_enables::get() == 4UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_senter_gloabl_function_enable()
-// {
-//     msrs::ia32_feature_control::senter_gloabl_function_enable::set(true);
-//     this->expect_true(msrs::ia32_feature_control::senter_gloabl_function_enable::get());
-
-//     msrs::ia32_feature_control::senter_gloabl_function_enable::set(false);
-//     this->expect_false(msrs::ia32_feature_control::senter_gloabl_function_enable::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_sgx_launch_control_enable()
-// {
-//     msrs::ia32_feature_control::sgx_launch_control_enable::set(true);
-//     this->expect_true(msrs::ia32_feature_control::sgx_launch_control_enable::get());
-
-//     msrs::ia32_feature_control::sgx_launch_control_enable::set(false);
-//     this->expect_false(msrs::ia32_feature_control::sgx_launch_control_enable::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_sgx_global_enable()
-// {
-//     msrs::ia32_feature_control::sgx_global_enable::set(true);
-//     this->expect_true(msrs::ia32_feature_control::sgx_global_enable::get());
-
-//     msrs::ia32_feature_control::sgx_global_enable::set(false);
-//     this->expect_false(msrs::ia32_feature_control::sgx_global_enable::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_feature_control_lmce()
-// {
-//     msrs::ia32_feature_control::lmce::set(true);
-//     this->expect_true(msrs::ia32_feature_control::lmce::get());
-
-//     msrs::ia32_feature_control::lmce::set(false);
-//     this->expect_false(msrs::ia32_feature_control::lmce::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_sysenter_cs()
-// {
-//     msrs::ia32_sysenter_cs::set(100UL);
-//     this->expect_true(msrs::ia32_sysenter_cs::get() == 100UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_sysenter_esp()
-// {
-//     msrs::ia32_sysenter_esp::set(100UL);
-//     this->expect_true(msrs::ia32_sysenter_esp::get() == 100UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_sysenter_eip()
-// {
-//     msrs::ia32_sysenter_eip::set(100UL);
-//     this->expect_true(msrs::ia32_sysenter_eip::get() == 100UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl()
-// {
-//     msrs::ia32_debugctl::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_debugctl::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_debugctl::dump();
-
-//     msrs::ia32_debugctl::set(0x0U);
-//     this->expect_true(msrs::ia32_debugctl::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_lbr()
-// {
-//     msrs::ia32_debugctl::lbr::set(true);
-//     this->expect_true(msrs::ia32_debugctl::lbr::get());
-
-//     msrs::ia32_debugctl::lbr::set(false);
-//     this->expect_false(msrs::ia32_debugctl::lbr::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_btf()
-// {
-//     msrs::ia32_debugctl::btf::set(true);
-//     this->expect_true(msrs::ia32_debugctl::btf::get());
-
-//     msrs::ia32_debugctl::btf::set(false);
-//     this->expect_false(msrs::ia32_debugctl::btf::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_tr()
-// {
-//     msrs::ia32_debugctl::tr::set(true);
-//     this->expect_true(msrs::ia32_debugctl::tr::get());
-
-//     msrs::ia32_debugctl::tr::set(false);
-//     this->expect_false(msrs::ia32_debugctl::tr::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_bts()
-// {
-//     msrs::ia32_debugctl::bts::set(true);
-//     this->expect_true(msrs::ia32_debugctl::bts::get());
-
-//     msrs::ia32_debugctl::bts::set(false);
-//     this->expect_false(msrs::ia32_debugctl::bts::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_btint()
-// {
-//     msrs::ia32_debugctl::btint::set(true);
-//     this->expect_true(msrs::ia32_debugctl::btint::get());
-
-//     msrs::ia32_debugctl::btint::set(false);
-//     this->expect_false(msrs::ia32_debugctl::btint::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_bt_off_os()
-// {
-//     msrs::ia32_debugctl::bt_off_os::set(true);
-//     this->expect_true(msrs::ia32_debugctl::bt_off_os::get());
-
-//     msrs::ia32_debugctl::bt_off_os::set(false);
-//     this->expect_false(msrs::ia32_debugctl::bt_off_os::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_bt_off_user()
-// {
-//     msrs::ia32_debugctl::bt_off_user::set(true);
-//     this->expect_true(msrs::ia32_debugctl::bt_off_user::get());
-
-//     msrs::ia32_debugctl::bt_off_user::set(false);
-//     this->expect_false(msrs::ia32_debugctl::bt_off_user::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_freeze_lbrs_on_pmi()
-// {
-//     msrs::ia32_debugctl::freeze_lbrs_on_pmi::set(true);
-//     this->expect_true(msrs::ia32_debugctl::freeze_lbrs_on_pmi::get());
-
-//     msrs::ia32_debugctl::freeze_lbrs_on_pmi::set(false);
-//     this->expect_false(msrs::ia32_debugctl::freeze_lbrs_on_pmi::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_freeze_perfmon_on_pmi()
-// {
-//     msrs::ia32_debugctl::freeze_perfmon_on_pmi::set(true);
-//     this->expect_true(msrs::ia32_debugctl::freeze_perfmon_on_pmi::get());
-
-//     msrs::ia32_debugctl::freeze_perfmon_on_pmi::set(false);
-//     this->expect_false(msrs::ia32_debugctl::freeze_perfmon_on_pmi::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_enable_uncore_pmi()
-// {
-//     msrs::ia32_debugctl::enable_uncore_pmi::set(true);
-//     this->expect_true(msrs::ia32_debugctl::enable_uncore_pmi::get());
-
-//     msrs::ia32_debugctl::enable_uncore_pmi::set(false);
-//     this->expect_false(msrs::ia32_debugctl::enable_uncore_pmi::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_freeze_while_smm()
-// {
-//     msrs::ia32_debugctl::freeze_while_smm::set(true);
-//     this->expect_true(msrs::ia32_debugctl::freeze_while_smm::get());
-
-//     msrs::ia32_debugctl::freeze_while_smm::set(false);
-//     this->expect_false(msrs::ia32_debugctl::freeze_while_smm::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_rtm_debug()
-// {
-//     msrs::ia32_debugctl::rtm_debug::set(true);
-//     this->expect_true(msrs::ia32_debugctl::rtm_debug::get());
-
-//     msrs::ia32_debugctl::rtm_debug::set(false);
-//     this->expect_false(msrs::ia32_debugctl::rtm_debug::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_debugctl_reserved()
-// {
-//     msrs::ia32_debugctl::reserved::set(0x100000000UL);
-//     this->expect_true(msrs::ia32_debugctl::reserved::get() == 0x100000000UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl()
-// {
-//     msrs::ia32_perf_global_ctrl::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_perf_global_ctrl::dump();
-
-//     msrs::ia32_perf_global_ctrl::set(0x0U);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc0()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc0::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc0::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc0::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc0::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc1()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc1::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc1::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc1::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc1::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc2()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc2::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc2::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc2::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc2::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc3()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc3::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc3::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc3::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc3::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc4()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc4::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc4::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc4::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc4::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc5()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc5::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc5::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc5::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc5::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc6()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc6::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc6::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc6::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc6::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_pmc7()
-// {
-//     msrs::ia32_perf_global_ctrl::pmc7::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::pmc7::get());
-
-//     msrs::ia32_perf_global_ctrl::pmc7::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::pmc7::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_fixed_ctr0()
-// {
-//     msrs::ia32_perf_global_ctrl::fixed_ctr0::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::fixed_ctr0::get());
-
-//     msrs::ia32_perf_global_ctrl::fixed_ctr0::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::fixed_ctr0::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_fixed_ctr1()
-// {
-//     msrs::ia32_perf_global_ctrl::fixed_ctr1::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::fixed_ctr1::get());
-
-//     msrs::ia32_perf_global_ctrl::fixed_ctr1::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::fixed_ctr1::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_perf_global_ctrl_fixed_ctr2()
-// {
-//     msrs::ia32_perf_global_ctrl::fixed_ctr2::set(true);
-//     this->expect_true(msrs::ia32_perf_global_ctrl::fixed_ctr2::get());
-
-//     msrs::ia32_perf_global_ctrl::fixed_ctr2::set(false);
-//     this->expect_false(msrs::ia32_perf_global_ctrl::fixed_ctr2::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic()
-// {
-//     g_msrs[msrs::ia32_vmx_basic::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_basic::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_vmx_basic::dump();
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_basic::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_revision_id()
-// {
-//     auto mask = msrs::ia32_vmx_basic::revision_id::mask;
-//     auto from = msrs::ia32_vmx_basic::revision_id::from;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::revision_id::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_vmxon_vmcs_region_size()
-// {
-//     auto mask = msrs::ia32_vmx_basic::vmxon_vmcs_region_size::mask;
-//     auto from = msrs::ia32_vmx_basic::vmxon_vmcs_region_size::from;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::vmxon_vmcs_region_size::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_physical_address_width()
-// {
-//     auto mask = msrs::ia32_vmx_basic::physical_address_width::mask;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::physical_address_width::get());
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_basic::physical_address_width::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_dual_monitor_mode_support()
-// {
-//     auto mask = msrs::ia32_vmx_basic::dual_monitor_mode_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::dual_monitor_mode_support::get());
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_basic::dual_monitor_mode_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_memory_type()
-// {
-//     auto mask = msrs::ia32_vmx_basic::memory_type::mask;
-//     auto from = msrs::ia32_vmx_basic::memory_type::from;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::memory_type::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_ins_outs_exit_information()
-// {
-//     auto mask = msrs::ia32_vmx_basic::ins_outs_exit_information::mask;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::ins_outs_exit_information::get());
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_basic::ins_outs_exit_information::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_basic_true_based_controls()
-// {
-//     auto mask = msrs::ia32_vmx_basic::true_based_controls::mask;
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_basic::true_based_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_basic::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_basic::true_based_controls::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc()
-// {
-//     g_msrs[msrs::ia32_vmx_misc::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_misc::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_vmx_misc::dump();
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_misc::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_preemption_timer_decrement()
-// {
-//     auto mask = msrs::ia32_vmx_misc::preemption_timer_decrement::mask;
-//     auto from = msrs::ia32_vmx_misc::preemption_timer_decrement::from;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::preemption_timer_decrement::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_store_efer_lma_on_vm_exit()
-// {
-//     auto mask = msrs::ia32_vmx_misc::store_efer_lma_on_vm_exit::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::store_efer_lma_on_vm_exit::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::store_efer_lma_on_vm_exit::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_activity_state_hlt_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::activity_state_hlt_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::activity_state_hlt_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::activity_state_hlt_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_activity_state_shutdown_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::activity_state_shutdown_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::activity_state_shutdown_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::activity_state_shutdown_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_activity_state_wait_for_sipi_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::activity_state_wait_for_sipi_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::activity_state_wait_for_sipi_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::activity_state_wait_for_sipi_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_processor_trace_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::processor_trace_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::processor_trace_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::processor_trace_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_rdmsr_in_smm_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::rdmsr_in_smm_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::rdmsr_in_smm_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::rdmsr_in_smm_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_cr3_targets()
-// {
-//     auto mask = msrs::ia32_vmx_misc::cr3_targets::mask;
-//     auto from = msrs::ia32_vmx_misc::cr3_targets::from;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::cr3_targets::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_max_num_msr_load_store_on_exit()
-// {
-//     auto mask = msrs::ia32_vmx_misc::max_num_msr_load_store_on_exit::mask;
-//     auto from = msrs::ia32_vmx_misc::max_num_msr_load_store_on_exit::from;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::max_num_msr_load_store_on_exit::get() == mask >> from);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_vmxoff_blocked_smi_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::vmxoff_blocked_smi_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::vmxoff_blocked_smi_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::vmxoff_blocked_smi_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_vmwrite_all_fields_support()
-// {
-//     auto mask = msrs::ia32_vmx_misc::vmwrite_all_fields_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::vmwrite_all_fields_support::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::vmwrite_all_fields_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_misc_injection_with_instruction_length_of_zero()
-// {
-//     auto mask = msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::mask;
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get());
-
-//     g_msrs[msrs::ia32_vmx_misc::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_cr0_fixed0()
-// {
-//     g_msrs[msrs::ia32_vmx_cr0_fixed0::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_cr0_fixed0::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     g_msrs[msrs::ia32_vmx_cr0_fixed0::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_cr0_fixed0::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_cr0_fixed1()
-// {
-//     g_msrs[msrs::ia32_vmx_cr0_fixed1::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_cr0_fixed1::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     g_msrs[msrs::ia32_vmx_cr0_fixed1::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_cr0_fixed1::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_cr4_fixed0()
-// {
-//     g_msrs[msrs::ia32_vmx_cr4_fixed0::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_cr4_fixed0::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     g_msrs[msrs::ia32_vmx_cr4_fixed0::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_cr4_fixed0::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_cr4_fixed1()
-// {
-//     g_msrs[msrs::ia32_vmx_cr4_fixed1::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_cr4_fixed1::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     g_msrs[msrs::ia32_vmx_cr4_fixed1::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_cr4_fixed1::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2()
-// {
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::get() == 0x00000000FFFFFFFFUL);
-
-//     msrs::ia32_vmx_procbased_ctls2::dump();
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0x0UL;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::get() == 0x0UL);
-
-//     msrs::ia32_vmx_procbased_ctls2::dump();
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::allowed0() == 0xFFFFFFFFU);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::allowed1() == 0x00000000U);
-
-//     msrs::ia32_vmx_procbased_ctls2::dump();
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0xFFFFFFFF00000000U;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::allowed0() == 0x00000000U);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::allowed1() == 0xFFFFFFFFU);
-
-//     msrs::ia32_vmx_procbased_ctls2::dump();
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_virtualize_apic_accesses()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_ept()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_ept::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_ept::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_ept::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_descriptor_table_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_rdtscp()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_virtualize_x2apic_mode()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_vpid()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_vpid::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vpid::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vpid::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_wbinvd_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_unrestricted_guest()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_apic_register_virtualization()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_virtual_interrupt_delivery()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_pause_loop_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_rdrand_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_invpcid()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_invpcid::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_vm_functions()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_vmcs_shadowing()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_rdseed_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_pml()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_pml::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_pml::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_pml::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_ept_violation_ve()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_procbased_ctls2_enable_xsaves_xrstors()
-// {
-//     auto mask = msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::mask;
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::get());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap()
-// {
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_vmx_ept_vpid_cap::dump();
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_execute_only_translation()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::execute_only_translation::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::execute_only_translation::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::execute_only_translation::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_page_walk_length_of_4()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::page_walk_length_of_4::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::page_walk_length_of_4::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::page_walk_length_of_4::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_memory_type_uncacheable_supported()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_memory_type_write_back_supported()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_pde_2mb_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::pde_2mb_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::pde_2mb_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::pde_2mb_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_pdpte_1gb_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::pdpte_1gb_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::pdpte_1gb_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::pdpte_1gb_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invept_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invept_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invept_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invept_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_accessed_dirty_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::accessed_dirty_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::accessed_dirty_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::accessed_dirty_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invept_single_context_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invept_single_context_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invept_single_context_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invept_single_context_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invept_all_context_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invept_all_context_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invept_all_context_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invept_all_context_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invvpid_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invvpid_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invvpid_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invvpid_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invvpid_individual_address_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invvpid_individual_address_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invvpid_individual_address_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invvpid_individual_address_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invvpid_single_context_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invvpid_all_context_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invvpid_all_context_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invvpid_all_context_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invvpid_all_context_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_ept_vpid_cap_invvpid_single_context_retaining_globals_support()
-// {
-//     auto mask = msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_retaining_globals_support::mask;
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_retaining_globals_support::get());
-
-//     g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_retaining_globals_support::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls()
-// {
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::get() == 0x00000000FFFFFFFFUL);
-
-//     msrs::ia32_vmx_true_pinbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x0UL;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::get() == 0x0UL);
-
-//     msrs::ia32_vmx_true_pinbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::allowed0() == 0xFFFFFFFFU);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::allowed1() == 0x00000000U);
-
-//     msrs::ia32_vmx_true_pinbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 0xFFFFFFFF00000000U;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::allowed0() == 0x00000000U);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::allowed1() == 0xFFFFFFFFU);
-
-//     msrs::ia32_vmx_true_pinbased_ctls::dump();
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls_external_interrupt_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls_nmi_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls_virtual_nmis()
-// {
-//     auto mask = msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls_activate_vmx_preemption_timer()
-// {
-//     auto mask = msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_pinbased_ctls_process_posted_interrupts()
-// {
-//     auto mask = msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::get());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls()
-// {
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::get() == 0x00000000FFFFFFFFUL);
-
-//     msrs::ia32_vmx_true_procbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 0x0UL;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::get() == 0x0UL);
-
-//     msrs::ia32_vmx_true_procbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::allowed0() == 0xFFFFFFFFU);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::allowed1() == 0x00000000U);
-
-//     msrs::ia32_vmx_true_procbased_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 0xFFFFFFFF00000000U;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::allowed0() == 0x00000000U);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::allowed1() == 0xFFFFFFFFU);
-
-//     msrs::ia32_vmx_true_procbased_ctls::dump();
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_interrupt_window_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_use_tsc_offsetting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_hlt_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_invlpg_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_mwait_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_rdpmc_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_rdtsc_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_cr3_load_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_cr3_store_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_cr8_load_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_cr8_store_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_use_tpr_shadow()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_nmi_window_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_mov_dr_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_unconditional_io_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_use_io_bitmaps()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_monitor_trap_flag()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_use_msr_bitmap()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_monitor_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_pause_exiting()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::pause_exiting::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_procbased_ctls_activate_secondary_controls()
-// {
-//     auto mask = msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls()
-// {
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::get() == 0x00000000FFFFFFFFUL);
-
-//     msrs::ia32_vmx_true_exit_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 0x0UL;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::get() == 0x0UL);
-
-//     msrs::ia32_vmx_true_exit_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::allowed0() == 0xFFFFFFFFU);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::allowed1() == 0x00000000U);
-
-//     msrs::ia32_vmx_true_exit_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 0xFFFFFFFF00000000U;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::allowed0() == 0x00000000U);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::allowed1() == 0xFFFFFFFFU);
-
-//     msrs::ia32_vmx_true_exit_ctls::dump();
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_save_debug_controls()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::save_debug_controls::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_host_address_space_size()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::host_address_space_size::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_load_ia32_perf_global_ctrl()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_acknowledge_interrupt_on_exit()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_save_ia32_pat()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_load_ia32_pat()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_save_ia32_efer()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_load_ia32_efer()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_save_vmx_preemption_timer_value()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_exit_ctls_clear_ia32_bndcfgs()
-// {
-//     auto mask = msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::get());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls()
-// {
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::get() == 0x00000000FFFFFFFFUL);
-
-//     msrs::ia32_vmx_true_entry_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 0x0UL;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::get() == 0x0UL);
-
-//     msrs::ia32_vmx_true_entry_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 0x00000000FFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::allowed0() == 0xFFFFFFFFU);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::allowed1() == 0x00000000U);
-
-//     msrs::ia32_vmx_true_entry_ctls::dump();
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 0xFFFFFFFF00000000U;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::allowed0() == 0x00000000U);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::allowed1() == 0xFFFFFFFFU);
-
-//     msrs::ia32_vmx_true_entry_ctls::dump();
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_load_debug_controls()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::load_debug_controls::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_ia_32e_mode_guest()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_entry_to_smm()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::entry_to_smm::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_deactivate_dual_monitor_treatment()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_load_ia32_perf_global_ctrl()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_load_ia32_pat()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_load_ia32_efer()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_true_entry_ctls_load_ia32_bndcfgs()
-// {
-//     auto mask = msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::mask;
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask;
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::get());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed0());
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
-//     this->expect_true(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed0());
-//     this->expect_false(msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_vmfunc()
-// {
-//     g_msrs[msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_vmfunc::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     g_msrs[msrs::ia32_vmx_vmfunc::addr] = 0x0U;
-//     this->expect_true(msrs::ia32_vmx_vmfunc::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_vmx_vmfunc_eptp_switching()
-// {
-//     g_msrs[msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFFUL;
-//     this->expect_true(msrs::ia32_vmx_vmfunc::eptp_switching::is_allowed1());
-
-//     g_msrs[msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFEUL;
-//     this->expect_false(msrs::ia32_vmx_vmfunc::eptp_switching::is_allowed1());
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer()
-// {
-//     msrs::ia32_efer::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_efer::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_efer::dump();
-
-//     msrs::ia32_efer::set(0x0U);
-//     this->expect_true(msrs::ia32_efer::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer_sce()
-// {
-//     msrs::ia32_efer::sce::set(true);
-//     this->expect_true(msrs::ia32_efer::sce::get());
-
-//     msrs::ia32_efer::sce::set(false);
-//     this->expect_false(msrs::ia32_efer::sce::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer_lme()
-// {
-//     msrs::ia32_efer::lme::set(true);
-//     this->expect_true(msrs::ia32_efer::lme::get());
-
-//     msrs::ia32_efer::lme::set(false);
-//     this->expect_false(msrs::ia32_efer::lme::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer_lma()
-// {
-//     msrs::ia32_efer::lma::set(true);
-//     this->expect_true(msrs::ia32_efer::lma::get());
-
-//     msrs::ia32_efer::lma::set(false);
-//     this->expect_false(msrs::ia32_efer::lma::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer_nxe()
-// {
-//     msrs::ia32_efer::nxe::set(true);
-//     this->expect_true(msrs::ia32_efer::nxe::get());
-
-//     msrs::ia32_efer::nxe::set(false);
-//     this->expect_false(msrs::ia32_efer::nxe::get());
-// }
-
-// void
-// intrinsics_ut::test_ia32_efer_reserved()
-// {
-//     msrs::ia32_efer::reserved::set(0x10000UL);
-//     this->expect_true(msrs::ia32_efer::reserved::get() == 0x10000UL);
-// }
-
-// void
-// intrinsics_ut::test_ia32_fs_base()
-// {
-//     msrs::ia32_fs_base::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_fs_base::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_fs_base::set(0x0U);
-//     this->expect_true(msrs::ia32_fs_base::get() == 0x0U);
-// }
-
-// void
-// intrinsics_ut::test_ia32_gs_base()
-// {
-//     msrs::ia32_gs_base::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_gs_base::get() == 0xFFFFFFFFFFFFFFFFUL);
-
-//     msrs::ia32_gs_base::set(0x0U);
-//     this->expect_true(msrs::ia32_gs_base::get() == 0x0U);
-// }
+TEST_CASE("general_msr_access")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::set(0x1UL, 100UL);
+    CHECK(intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(0x1UL)) == 100UL);
+}
+
+TEST_CASE("ia32_monitor_filter_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000006UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_monitor_filter_size::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_platform_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000017UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_platform_id::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_platform_id_platform_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000017UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_platform_id::platform_id::get() == 0x0000000000000007ULL);
+}
+
+TEST_CASE("ia32_feature_control")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_feature_control::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_feature_control_lock_bit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::lock_bit::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::lock_bit::get());
+
+    intel_x64::msrs::ia32_feature_control::lock_bit::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::lock_bit::get());
+}
+
+TEST_CASE("ia32_feature_control_enable_vmx_inside_smx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::enable_vmx_inside_smx::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::enable_vmx_inside_smx::get());
+
+    intel_x64::msrs::ia32_feature_control::enable_vmx_inside_smx::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::enable_vmx_inside_smx::get());
+}
+
+TEST_CASE("ia32_feature_control_enable_vmx_outside_smx")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::enable_vmx_outside_smx::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::enable_vmx_outside_smx::get());
+
+    intel_x64::msrs::ia32_feature_control::enable_vmx_outside_smx::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::enable_vmx_outside_smx::get());
+}
+
+TEST_CASE("ia32_feature_control_senter_local_function_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::senter_local_function_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::senter_local_function_enable::get());
+
+    intel_x64::msrs::ia32_feature_control::senter_local_function_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::senter_local_function_enable::get());
+}
+
+TEST_CASE("ia32_feature_control_senter_global_function_enables")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::senter_global_function_enables::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::senter_global_function_enables::get());
+
+    intel_x64::msrs::ia32_feature_control::senter_global_function_enables::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::senter_global_function_enables::get());
+}
+
+TEST_CASE("ia32_feature_control_sgx_launch_control_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::sgx_launch_control_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::sgx_launch_control_enable::get());
+
+    intel_x64::msrs::ia32_feature_control::sgx_launch_control_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::sgx_launch_control_enable::get());
+}
+
+TEST_CASE("ia32_feature_control_sgx_global_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::sgx_global_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::sgx_global_enable::get());
+
+    intel_x64::msrs::ia32_feature_control::sgx_global_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::sgx_global_enable::get());
+}
+
+TEST_CASE("ia32_feature_control_lmce")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_feature_control::lmce::set(true);
+    CHECK(intel_x64::msrs::ia32_feature_control::lmce::get());
+
+    intel_x64::msrs::ia32_feature_control::lmce::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_feature_control::lmce::get());
+}
+
+TEST_CASE("ia32_tsc_adjust")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_tsc_adjust::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_tsc_adjust::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_tsc_adjust_thread_adjust")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_tsc_adjust::thread_adjust::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_tsc_adjust::thread_adjust::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_bios_updt_trig")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bios_updt_trig::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(g_msrs[0x00000079UL] == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_bios_sign_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000008BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_bios_sign_id::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_bios_sign_id_bios_sign_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bios_sign_id::bios_sign_id::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_bios_sign_id::bios_sign_id::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sgxlepubkeyhash0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sgxlepubkeyhash0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sgxlepubkeyhash0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sgxlepubkeyhash1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sgxlepubkeyhash1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sgxlepubkeyhash1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sgxlepubkeyhash2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sgxlepubkeyhash2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sgxlepubkeyhash2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sgxlepubkeyhash3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sgxlepubkeyhash3::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sgxlepubkeyhash3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_smm_monitor_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smm_monitor_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_smm_monitor_ctl_valid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::valid::set(true);
+    CHECK(intel_x64::msrs::ia32_smm_monitor_ctl::valid::get());
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::valid::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_smm_monitor_ctl::valid::get());
+}
+
+TEST_CASE("ia32_smm_monitor_ctl_vmxoff")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::vmxoff::set(true);
+    CHECK(intel_x64::msrs::ia32_smm_monitor_ctl::vmxoff::get());
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::vmxoff::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_smm_monitor_ctl::vmxoff::get());
+}
+
+TEST_CASE("ia32_smm_monitor_ctl_mseg_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smm_monitor_ctl::mseg_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smm_monitor_ctl::mseg_base::get() == 0x00000000000FFFFFULL);
+}
+
+TEST_CASE("ia32_smbase")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000009EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_smbase::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc3::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc4::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc5::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc6::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pmc7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pmc7::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pmc7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_cs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sysenter_cs::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sysenter_cs::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_esp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sysenter_esp::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sysenter_esp::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_eip")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_sysenter_eip::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_sysenter_eip::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perfevtsel0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perfevtsel0_event_select")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::event_select::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::event_select::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_perfevtsel0_umask")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::umask::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::umask::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_perfevtsel0_usr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::usr::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::usr::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::usr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::usr::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::os::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::os::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::os::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_edge")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::edge::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::edge::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::edge::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::edge::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_pc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::pc::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::pc::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::pc::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::pc::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_interrupt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::interrupt::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::interrupt::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::interrupt::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::interrupt::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_anythread")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::anythread::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::anythread::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::anythread::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::anythread::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::en::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::en::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::en::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_inv")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::inv::set(true);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::inv::get());
+
+    intel_x64::msrs::ia32_perfevtsel0::inv::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perfevtsel0::inv::get());
+}
+
+TEST_CASE("ia32_perfevtsel0_cmask")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel0::cmask::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel0::cmask::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_perfevtsel1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perfevtsel2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perfevtsel3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perfevtsel3::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perfevtsel3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000198UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_status_state_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000198UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_status::state_value::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_perf_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perf_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_ctl_state_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_ctl::state_value::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perf_ctl::state_value::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_perf_ctl_ida_engage")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_ctl::ida_engage::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_ctl::ida_engage::get());
+
+    intel_x64::msrs::ia32_perf_ctl::ida_engage::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_ctl::ida_engage::get());
+}
+
+TEST_CASE("ia32_clock_modulation")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_clock_modulation::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_clock_modulation::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_clock_modulation_ext_duty_cycle")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_clock_modulation::ext_duty_cycle::set(true);
+    CHECK(intel_x64::msrs::ia32_clock_modulation::ext_duty_cycle::get());
+
+    intel_x64::msrs::ia32_clock_modulation::ext_duty_cycle::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_clock_modulation::ext_duty_cycle::get());
+}
+
+TEST_CASE("ia32_clock_modulation_duty_cycle_values")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_clock_modulation::duty_cycle_values::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_clock_modulation::duty_cycle_values::get() == 0x0000000000000007ULL);
+}
+
+TEST_CASE("ia32_clock_modulation_enable_modulation")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_clock_modulation::enable_modulation::set(true);
+    CHECK(intel_x64::msrs::ia32_clock_modulation::enable_modulation::get());
+
+    intel_x64::msrs::ia32_clock_modulation::enable_modulation::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_clock_modulation::enable_modulation::get());
+}
+
+TEST_CASE("ia32_therm_interrupt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_therm_interrupt_high_temp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::high_temp::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::high_temp::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::high_temp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::high_temp::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_low_temp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::low_temp::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::low_temp::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::low_temp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::low_temp::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_prochot")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::prochot::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::prochot::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::prochot::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::prochot::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_forcepr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::forcepr::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::forcepr::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::forcepr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::forcepr::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_crit_temp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::crit_temp::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::crit_temp::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::crit_temp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::crit_temp::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_threshold_1_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_1_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::threshold_1_enable::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_1_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::threshold_1_enable::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_threshold_1_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_1_value::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::threshold_1_value::get() == 0x000000000000007FULL);
+}
+
+TEST_CASE("ia32_therm_interrupt_threshold_2_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_2_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::threshold_2_enable::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_2_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::threshold_2_enable::get());
+}
+
+TEST_CASE("ia32_therm_interrupt_threshold_2_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::threshold_2_value::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::threshold_2_value::get() == 0x000000000000007FULL);
+}
+
+TEST_CASE("ia32_therm_interrupt_power_limit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_interrupt::power_limit::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_interrupt::power_limit::get());
+
+    intel_x64::msrs::ia32_therm_interrupt::power_limit::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_interrupt::power_limit::get());
+}
+
+TEST_CASE("ia32_therm_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_therm_status_therm_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::therm_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::therm_status::get());
+}
+
+TEST_CASE("ia32_therm_status_thermal_status_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::thermal_status_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::thermal_status_log::get());
+
+    intel_x64::msrs::ia32_therm_status::thermal_status_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::thermal_status_log::get());
+}
+
+TEST_CASE("ia32_therm_status_forcepr_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000004ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::forcepr_event::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::forcepr_event::get());
+}
+
+TEST_CASE("ia32_therm_status_forcepr_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::forcepr_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::forcepr_log::get());
+
+    intel_x64::msrs::ia32_therm_status::forcepr_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::forcepr_log::get());
+}
+
+TEST_CASE("ia32_therm_status_crit_temp_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000010ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::crit_temp_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::crit_temp_status::get());
+}
+
+TEST_CASE("ia32_therm_status_crit_temp_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::crit_temp_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::crit_temp_log::get());
+
+    intel_x64::msrs::ia32_therm_status::crit_temp_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::crit_temp_log::get());
+}
+
+TEST_CASE("ia32_therm_status_therm_threshold1_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000040ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::therm_threshold1_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::therm_threshold1_status::get());
+}
+
+TEST_CASE("ia32_therm_status_therm_threshold1_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::therm_threshold1_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::therm_threshold1_log::get());
+
+    intel_x64::msrs::ia32_therm_status::therm_threshold1_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::therm_threshold1_log::get());
+}
+
+TEST_CASE("ia32_therm_status_therm_threshold2_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000100ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::therm_threshold2_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::therm_threshold2_status::get());
+}
+
+TEST_CASE("ia32_therm_status_therm_threshold2_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::therm_threshold2_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::therm_threshold2_log::get());
+
+    intel_x64::msrs::ia32_therm_status::therm_threshold2_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::therm_threshold2_log::get());
+}
+
+TEST_CASE("ia32_therm_status_power_limit_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000000400ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::power_limit_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::power_limit_status::get());
+}
+
+TEST_CASE("ia32_therm_status_power_limit_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::power_limit_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::power_limit_log::get());
+
+    intel_x64::msrs::ia32_therm_status::power_limit_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::power_limit_log::get());
+}
+
+TEST_CASE("ia32_therm_status_current_limit_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000001000ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::current_limit_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::current_limit_status::get());
+}
+
+TEST_CASE("ia32_therm_status_current_limit_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::current_limit_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::current_limit_log::get());
+
+    intel_x64::msrs::ia32_therm_status::current_limit_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::current_limit_log::get());
+}
+
+TEST_CASE("ia32_therm_status_cross_domain_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000000004000ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::cross_domain_status::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::cross_domain_status::get());
+}
+
+TEST_CASE("ia32_therm_status_cross_domain_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_therm_status::cross_domain_log::set(true);
+    CHECK(intel_x64::msrs::ia32_therm_status::cross_domain_log::get());
+
+    intel_x64::msrs::ia32_therm_status::cross_domain_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::cross_domain_log::get());
+}
+
+TEST_CASE("ia32_therm_status_digital_readout")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::digital_readout::get() == 0x000000000000007FULL);
+}
+
+TEST_CASE("ia32_therm_status_resolution_celcius")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::resolution_celcius::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_therm_status_reading_valid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000019CUL] = 0x0000000080000000ULL;
+    CHECK(intel_x64::msrs::ia32_therm_status::reading_valid::get());
+
+    g_msrs[0x0000019CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_therm_status::reading_valid::get());
+}
+
+TEST_CASE("ia32_misc_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_misc_enable::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_misc_enable_fast_strings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::fast_strings::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::fast_strings::get());
+
+    intel_x64::msrs::ia32_misc_enable::fast_strings::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::fast_strings::get());
+}
+
+TEST_CASE("ia32_misc_enable_auto_therm_control")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::auto_therm_control::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::auto_therm_control::get());
+
+    intel_x64::msrs::ia32_misc_enable::auto_therm_control::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::auto_therm_control::get());
+}
+
+TEST_CASE("ia32_misc_enable_perf_monitor")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001A0UL] = 0x0000000000000080ULL;
+    CHECK(intel_x64::msrs::ia32_misc_enable::perf_monitor::get());
+
+    g_msrs[0x000001A0UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::perf_monitor::get());
+}
+
+TEST_CASE("ia32_misc_enable_branch_trace_storage")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001A0UL] = 0x0000000000000800ULL;
+    CHECK(intel_x64::msrs::ia32_misc_enable::branch_trace_storage::get());
+
+    g_msrs[0x000001A0UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::branch_trace_storage::get());
+}
+
+TEST_CASE("ia32_misc_enable_processor_sampling")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001A0UL] = 0x0000000000001000ULL;
+    CHECK(intel_x64::msrs::ia32_misc_enable::processor_sampling::get());
+
+    g_msrs[0x000001A0UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::processor_sampling::get());
+}
+
+TEST_CASE("ia32_misc_enable_intel_speedstep")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::intel_speedstep::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::intel_speedstep::get());
+
+    intel_x64::msrs::ia32_misc_enable::intel_speedstep::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::intel_speedstep::get());
+}
+
+TEST_CASE("ia32_misc_enable_monitor_fsm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::monitor_fsm::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::monitor_fsm::get());
+
+    intel_x64::msrs::ia32_misc_enable::monitor_fsm::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::monitor_fsm::get());
+}
+
+TEST_CASE("ia32_misc_enable_limit_cpuid_maxval")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::limit_cpuid_maxval::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::limit_cpuid_maxval::get());
+
+    intel_x64::msrs::ia32_misc_enable::limit_cpuid_maxval::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::limit_cpuid_maxval::get());
+}
+
+TEST_CASE("ia32_misc_enable_xtpr_message")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::xtpr_message::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::xtpr_message::get());
+
+    intel_x64::msrs::ia32_misc_enable::xtpr_message::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::xtpr_message::get());
+}
+
+TEST_CASE("ia32_misc_enable_xd_bit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_misc_enable::xd_bit::set(true);
+    CHECK(intel_x64::msrs::ia32_misc_enable::xd_bit::get());
+
+    intel_x64::msrs::ia32_misc_enable::xd_bit::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_misc_enable::xd_bit::get());
+}
+
+TEST_CASE("ia32_energy_perf_bias")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_energy_perf_bias::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_energy_perf_bias::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_energy_perf_bias_power_policy")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_energy_perf_bias::power_policy::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_energy_perf_bias::power_policy::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_package_therm_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_status::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_status::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_prochot_event")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000004ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_prochot_event::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_prochot_event::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_prochot_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_prochot_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_prochot_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_prochot_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_prochot_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_crit_temp_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000010ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_status::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_status::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_crit_temp_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_crit_temp_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_thresh1_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000040ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_status::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_status::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_thresh1_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh1_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_thresh2_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000100ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_status::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_status::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_therm_thresh2_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_therm_thresh2_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_power_limit_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0x0000000000000400ULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_status::get());
+
+    g_msrs[0x000001B1UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_status::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_power_limit_log")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_log::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_log::get());
+
+    intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_log::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_status::pkg_power_limit_log::get());
+}
+
+TEST_CASE("ia32_package_therm_status_pkg_digital_readout")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001B1UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_package_therm_status::pkg_digital_readout::get() == 0x000000000000007FULL);
+}
+
+TEST_CASE("ia32_package_therm_interrupt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_high_temp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_high_temp::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_high_temp::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_high_temp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_high_temp::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_low_temp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_low_temp::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_low_temp::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_low_temp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_low_temp::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_prochot")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_prochot::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_prochot::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_prochot::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_prochot::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_overheat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_overheat::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_overheat::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_overheat::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_overheat::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_threshold_1_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_value::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_value::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_value::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_value::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_threshold_1_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_enable::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_1_enable::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_threshold_2_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_value::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_value::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_value::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_value::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_threshold_2_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_enable::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_threshold_2_enable::get());
+}
+
+TEST_CASE("ia32_package_therm_interrupt_pkg_power_limit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_power_limit::set(true);
+    CHECK(intel_x64::msrs::ia32_package_therm_interrupt::pkg_power_limit::get());
+
+    intel_x64::msrs::ia32_package_therm_interrupt::pkg_power_limit::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_package_therm_interrupt::pkg_power_limit::get());
+}
+
+TEST_CASE("ia32_debugctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_debugctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_debugctl::dump();
+}
+
+TEST_CASE("ia32_debugctl_lbr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::lbr::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::lbr::get());
+
+    intel_x64::msrs::ia32_debugctl::lbr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::lbr::get());
+}
+
+TEST_CASE("ia32_debugctl_btf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::btf::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::btf::get());
+
+    intel_x64::msrs::ia32_debugctl::btf::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::btf::get());
+}
+
+TEST_CASE("ia32_debugctl_tr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::tr::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::tr::get());
+
+    intel_x64::msrs::ia32_debugctl::tr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::tr::get());
+}
+
+TEST_CASE("ia32_debugctl_bts")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::bts::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::bts::get());
+
+    intel_x64::msrs::ia32_debugctl::bts::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::bts::get());
+}
+
+TEST_CASE("ia32_debugctl_btint")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::btint::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::btint::get());
+
+    intel_x64::msrs::ia32_debugctl::btint::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::btint::get());
+}
+
+TEST_CASE("ia32_debugctl_bt_off_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::bt_off_os::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::bt_off_os::get());
+
+    intel_x64::msrs::ia32_debugctl::bt_off_os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::bt_off_os::get());
+}
+
+TEST_CASE("ia32_debugctl_bt_off_user")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::bt_off_user::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::bt_off_user::get());
+
+    intel_x64::msrs::ia32_debugctl::bt_off_user::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::bt_off_user::get());
+}
+
+TEST_CASE("ia32_debugctl_freeze_lbrs_on_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::freeze_lbrs_on_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::freeze_lbrs_on_pmi::get());
+
+    intel_x64::msrs::ia32_debugctl::freeze_lbrs_on_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::freeze_lbrs_on_pmi::get());
+}
+
+TEST_CASE("ia32_debugctl_freeze_perfmon_on_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::freeze_perfmon_on_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::freeze_perfmon_on_pmi::get());
+
+    intel_x64::msrs::ia32_debugctl::freeze_perfmon_on_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::freeze_perfmon_on_pmi::get());
+}
+
+TEST_CASE("ia32_debugctl_enable_uncore_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::enable_uncore_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::enable_uncore_pmi::get());
+
+    intel_x64::msrs::ia32_debugctl::enable_uncore_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::enable_uncore_pmi::get());
+}
+
+TEST_CASE("ia32_debugctl_freeze_while_smm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::freeze_while_smm::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::freeze_while_smm::get());
+
+    intel_x64::msrs::ia32_debugctl::freeze_while_smm::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::freeze_while_smm::get());
+}
+
+TEST_CASE("ia32_debugctl_rtm_debug")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::rtm_debug::set(true);
+    CHECK(intel_x64::msrs::ia32_debugctl::rtm_debug::get());
+
+    intel_x64::msrs::ia32_debugctl::rtm_debug::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debugctl::rtm_debug::get());
+}
+
+TEST_CASE("ia32_debugctl_reserved")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debugctl::reserved::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_debugctl::reserved::get() == 0xFFFFFFFFFFFF003CULL);
+}
+
+TEST_CASE("ia32_smrr_physbase")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physbase::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smrr_physbase::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_smrr_physbase_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physbase::type::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smrr_physbase::type::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_smrr_physbase_physbase")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physbase::physbase::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smrr_physbase::physbase::get() == 0x00000000000FFFFFULL);
+}
+
+TEST_CASE("ia32_smrr_physmask")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physmask::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smrr_physmask::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_smrr_physmask_valid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physmask::valid::set(true);
+    CHECK(intel_x64::msrs::ia32_smrr_physmask::valid::get());
+
+    intel_x64::msrs::ia32_smrr_physmask::valid::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_smrr_physmask::valid::get());
+}
+
+TEST_CASE("ia32_smrr_physmask_physmask")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_smrr_physmask::physmask::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_smrr_physmask::physmask::get() == 0x00000000000FFFFFULL);
+}
+
+TEST_CASE("ia32_platform_dca_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000001F8UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_platform_dca_cap::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_cpu_dca_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_cpu_dca_cap::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_cpu_dca_cap::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_dca_0_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_dca_0_cap_dca_active")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::dca_active::set(true);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::dca_active::get());
+
+    intel_x64::msrs::ia32_dca_0_cap::dca_active::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_dca_0_cap::dca_active::get());
+}
+
+TEST_CASE("ia32_dca_0_cap_transaction")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::transaction::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::transaction::get() == 0x0000000000000003ULL);
+}
+
+TEST_CASE("ia32_dca_0_cap_dca_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::dca_type::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::dca_type::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_dca_0_cap_dca_queue_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::dca_queue_size::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::dca_queue_size::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_dca_0_cap_dca_delay")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::dca_delay::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::dca_delay::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_dca_0_cap_sw_block")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::sw_block::set(true);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::sw_block::get());
+
+    intel_x64::msrs::ia32_dca_0_cap::sw_block::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_dca_0_cap::sw_block::get());
+}
+
+TEST_CASE("ia32_dca_0_cap_hw_block")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_dca_0_cap::hw_block::set(true);
+    CHECK(intel_x64::msrs::ia32_dca_0_cap::hw_block::get());
+
+    intel_x64::msrs::ia32_dca_0_cap::hw_block::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_dca_0_cap::hw_block::get());
+}
+
+TEST_CASE("ia32_mtrr_physbase0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000200UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000201UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000202UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000203UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000204UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000205UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000206UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000207UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000208UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000209UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000020FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase8")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000210UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase8::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask8")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000211UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask8::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physbase9")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000212UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physbase9::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_physmask9")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000213UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_physmask9::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix64k_00000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000250UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix64k_00000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix16k_80000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000258UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix16k_80000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix16k_A0000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000259UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix16k_A0000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_C0000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000268UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_C0000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_C8000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000269UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_C8000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_D0000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_D0000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_D8000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_D8000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_E0000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_E0000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_E8000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_E8000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_F0000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_F0000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_fix4k_F8000")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000026FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mtrr_fix4k_F8000::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc0_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc0_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc0_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc0_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc0_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc0_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc0_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc0_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc0_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc0_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc0_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc1_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc1_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc1_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc1_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc1_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc1_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc1_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc1_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc1_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc1_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc1_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc2_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc2_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc2_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc2_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc2_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc2_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc2_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc2_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc2_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc2_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc2_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc3_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc3_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc3_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc3_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc3_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc3_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc3_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc3_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc3_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc3_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc3_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc4_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc4_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc4_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc4_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc4_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc4_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc4_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc4_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc4_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc4_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc4_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc5_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc5_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc5_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc5_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc5_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc5_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc5_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc5_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc5_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc5_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc5_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc6_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc6_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc6_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc6_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc6_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc6_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc6_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc6_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc6_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc6_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc6_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc7_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc7_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc7_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc7_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc7_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc7_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc7_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc7_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc7_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc7_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc7_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc8_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc8_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc8_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc8_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc8_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc8_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc8_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc8_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc8_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc8_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc8_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc9_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc9_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc9_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc9_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc9_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc9_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc9_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc9_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc9_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc9_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc9_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc10_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc10_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc10_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc10_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc10_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc10_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc10_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc10_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc10_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc10_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc10_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc11_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc11_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc11_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc11_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc11_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc11_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc11_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc11_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc11_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc11_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc11_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc12_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc12_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc12_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc12_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc12_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc12_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc12_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc12_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc12_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc12_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc12_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc13_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc13_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc13_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc13_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc13_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc13_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc13_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc13_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc13_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc13_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc13_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc14_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc14_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc14_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc14_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc14_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc14_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc14_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc14_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc14_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc14_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc14_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc15_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc15_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc15_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc15_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc15_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc15_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc15_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc15_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc15_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc15_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc15_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc16_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc16_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc16_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc16_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc16_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc16_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc16_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc16_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc16_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc16_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc16_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc17_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc17_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc17_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc17_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc17_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc17_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc17_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc17_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc17_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc17_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc17_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc18_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc18_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc18_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc18_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc18_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc18_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc18_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc18_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc18_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc18_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc18_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc19_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc19_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc19_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc19_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc19_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc19_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc19_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc19_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc19_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc19_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc19_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc20_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc20_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc20_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc20_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc20_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc20_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc20_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc20_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc20_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc20_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc20_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc21_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc21_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc21_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc21_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc21_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc21_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc21_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc21_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc21_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc21_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc21_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc22_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc22_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc22_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc22_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc22_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc22_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc22_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc22_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc22_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc22_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc22_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc23_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc23_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc23_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc23_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc23_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc23_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc23_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc23_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc23_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc23_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc23_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc24_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc24_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc24_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc24_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc24_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc24_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc24_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc24_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc24_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc24_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc24_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc25_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc25_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc25_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc25_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc25_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc25_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc25_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc25_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc25_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc25_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc25_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc26_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc26_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc26_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc26_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc26_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc26_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc26_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc26_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc26_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc26_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc26_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc27_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc27_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc27_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc27_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc27_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc27_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc27_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc27_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc27_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc27_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc27_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc28_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc28_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc28_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc28_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc28_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc28_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc28_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc28_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc28_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc28_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc28_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc29_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc29_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc29_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc29_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc29_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc29_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc29_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc29_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc29_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc29_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc29_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc30_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc30_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc30_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc30_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc30_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc30_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc30_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc30_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc30_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc30_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc30_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mc31_ctl2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc31_ctl2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc31_ctl2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc31_ctl2_error_threshold")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc31_ctl2::error_threshold::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mc31_ctl2::error_threshold::get() == 0x0000000000007FFFULL);
+}
+
+TEST_CASE("ia32_mc31_ctl2_cmci_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mc31_ctl2::cmci_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mc31_ctl2::cmci_en::get());
+
+    intel_x64::msrs::ia32_mc31_ctl2::cmci_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mc31_ctl2::cmci_en::get());
+}
+
+TEST_CASE("ia32_mtrr_def_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mtrr_def_type::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mtrr_def_type::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrr_def_type_def_mem_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mtrr_def_type::def_mem_type::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mtrr_def_type::def_mem_type::get() == 0x0000000000000007ULL);
+}
+
+TEST_CASE("ia32_mtrr_def_type_fixed_range_mtrr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mtrr_def_type::fixed_range_mtrr::set(true);
+    CHECK(intel_x64::msrs::ia32_mtrr_def_type::fixed_range_mtrr::get());
+
+    intel_x64::msrs::ia32_mtrr_def_type::fixed_range_mtrr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mtrr_def_type::fixed_range_mtrr::get());
+}
+
+TEST_CASE("ia32_mtrr_def_type_mtrr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mtrr_def_type::mtrr::set(true);
+    CHECK(intel_x64::msrs::ia32_mtrr_def_type::mtrr::get());
+
+    intel_x64::msrs::ia32_mtrr_def_type::mtrr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mtrr_def_type::mtrr::get());
+}
+
+TEST_CASE("ia32_fixed_ctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_fixed_ctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_fixed_ctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_capabilities")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_capabilities_lbo_format")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::lbo_format::get() == 0x000000000000003FULL);
+}
+
+TEST_CASE("ia32_perf_capabilities_pebs_trap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0x0000000000000040ULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::pebs_trap::get());
+
+    g_msrs[0x00000345UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_capabilities::pebs_trap::get());
+}
+
+TEST_CASE("ia32_perf_capabilities_pebs_savearchregs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0x0000000000000080ULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::pebs_savearchregs::get());
+
+    g_msrs[0x00000345UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_capabilities::pebs_savearchregs::get());
+}
+
+TEST_CASE("ia32_perf_capabilities_pebs_record_format")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::pebs_record_format::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_perf_capabilities_freeze")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0x0000000000001000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::freeze::get());
+
+    g_msrs[0x00000345UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_capabilities::freeze::get());
+}
+
+TEST_CASE("ia32_perf_capabilities_counter_width")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000345UL] = 0x0000000000002000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_capabilities::counter_width::get());
+
+    g_msrs[0x00000345UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_capabilities::counter_width::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en0_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_os::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_os::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_os::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en0_usr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_usr::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_usr::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_usr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_usr::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en0_anythread")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_anythread::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_anythread::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_anythread::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_anythread::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en0_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_pmi::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en0_pmi::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en1_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_os::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_os::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_os::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en1_usr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_usr::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_usr::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_usr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_usr::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en1_anythread")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_anythread::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_anythread::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_anythread::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_anythread::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en1_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_pmi::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en1_pmi::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en2_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_os::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_os::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_os::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en2_usr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_usr::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_usr::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_usr::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_usr::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en2_anythread")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_anythread::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_anythread::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_anythread::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_anythread::get());
+}
+
+TEST_CASE("ia32_fixed_ctr_ctrl_en2_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_pmi::get());
+
+    intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_fixed_ctr_ctrl::en2_pmi::get());
+}
+
+TEST_CASE("ia32_perf_global_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000038EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_pmc0::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_pmc0::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_pmc1::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_pmc1::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_pmc2::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_pmc2::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_pmc3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc3::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_pmc3::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_pmc3::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_pmc3::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_fixedctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr0::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr0::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_fixedctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr1::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr1::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_fixedctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr2::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_fixedctr2::get());
+}
+
+TEST_CASE("ia32_perf_global_status_trace_topa_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::trace_topa_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::trace_topa_pmi::get());
+
+    intel_x64::msrs::ia32_perf_global_status::trace_topa_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::trace_topa_pmi::get());
+}
+
+TEST_CASE("ia32_perf_global_status_lbr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::lbr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::lbr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_status::lbr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::lbr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ctr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ctr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ctr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ctr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ctr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_status_asci")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::asci::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::asci::get());
+
+    intel_x64::msrs::ia32_perf_global_status::asci::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::asci::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovf_uncore")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_uncore::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovf_uncore::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovf_uncore::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovf_uncore::get());
+}
+
+TEST_CASE("ia32_perf_global_status_ovfbuf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::ovfbuf::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::ovfbuf::get());
+
+    intel_x64::msrs::ia32_perf_global_status::ovfbuf::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::ovfbuf::get());
+}
+
+TEST_CASE("ia32_perf_global_status_condchgd")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status::condchgd::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status::condchgd::get());
+
+    intel_x64::msrs::ia32_perf_global_status::condchgd::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status::condchgd::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::dump();
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc0::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc0::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc1::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc1::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc2::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc2::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc3::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc3::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc3::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc3::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc4::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc4::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc4::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc4::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc5::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc5::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc5::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc5::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc6::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc6::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc6::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc6::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_pmc7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc7::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::pmc7::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::pmc7::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::pmc7::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_fixed_ctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr0::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr0::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_fixed_ctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr1::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr1::get());
+}
+
+TEST_CASE("ia32_perf_global_ctrl_fixed_ctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr2::get());
+
+    intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ctrl::fixed_ctr2::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc0::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc0::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc1::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc1::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc2::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_pmc2::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_fixed_ctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr0::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr0::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_fixed_ctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr1::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr1::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_fixed_ctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr2::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_fixed_ctr2::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_trace_topa_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_trace_topa_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_trace_topa_pmi::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_trace_topa_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_trace_topa_pmi::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_lbr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::lbr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::lbr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::lbr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::lbr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_ctr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::ctr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::ctr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::ctr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::ctr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovf_uncore")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_uncore::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_uncore::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_uncore::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovf_uncore::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_ovfbuf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovfbuf::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovfbuf::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovfbuf::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_ovfbuf::get());
+}
+
+TEST_CASE("ia32_perf_global_ovf_ctrl_clear_condchgd")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_condchgd::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_condchgd::get());
+
+    intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_condchgd::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_ovf_ctrl::clear_condchgd::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc0::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc0::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc1::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc1::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc2::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_pmc2::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_fixed_ctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr0::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr0::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr0::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr0::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_fixed_ctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr1::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr1::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr1::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr1::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_fixed_ctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr2::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr2::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr2::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_fixed_ctr2::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_trace_topa_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::trace_topa_pmi::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::trace_topa_pmi::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::trace_topa_pmi::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::trace_topa_pmi::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_lbr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::lbr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::lbr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::lbr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::lbr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ctr_frz")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ctr_frz::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ctr_frz::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ctr_frz::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ctr_frz::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovf_uncore")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_uncore::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovf_uncore::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovf_uncore::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovf_uncore::get());
+}
+
+TEST_CASE("ia32_perf_global_status_set_ovfbuf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovfbuf::set(true);
+    CHECK(intel_x64::msrs::ia32_perf_global_status_set::ovfbuf::get());
+
+    intel_x64::msrs::ia32_perf_global_status_set::ovfbuf::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_status_set::ovfbuf::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_perf_global_inuse_perfevtsel0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel0::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel0::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_perfevtsel1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000000000002ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel1::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel1::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_perfevtsel2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000000000004ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel2::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::perfevtsel2::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_fixed_ctr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000100000000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr0::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr0::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_fixed_ctr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000200000000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr1::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr1::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_fixed_ctr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x0000000400000000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr2::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::fixed_ctr2::get());
+}
+
+TEST_CASE("ia32_perf_global_inuse_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000392UL] = 0x8000000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_perf_global_inuse::pmi::get());
+
+    g_msrs[0x00000392UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_perf_global_inuse::pmi::get());
+}
+
+TEST_CASE("ia32_pebs_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pebs_enable::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pebs_enable::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pebs_enable_pebs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pebs_enable::pebs::set(true);
+    CHECK(intel_x64::msrs::ia32_pebs_enable::pebs::get());
+
+    intel_x64::msrs::ia32_pebs_enable::pebs::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_pebs_enable::pebs::get());
+}
+
+TEST_CASE("ia32_mc6_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000418UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc6_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc6_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000419UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc6_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc6_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc6_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc6_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc6_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc7_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc7_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc7_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc7_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc7_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc7_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc7_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000041FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc7_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc8_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000420UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc8_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc8_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000421UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc8_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc8_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000422UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc8_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc8_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000423UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc8_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc9_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000424UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc9_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc9_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000425UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc9_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc9_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000426UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc9_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc9_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000427UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc9_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc10_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000428UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc10_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc10_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000429UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc10_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc10_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc10_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc10_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc10_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc11_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc11_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc11_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc11_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc11_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc11_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc11_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000042FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc11_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc12_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000430UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc12_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc12_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000431UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc12_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc12_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000432UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc12_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc12_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000433UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc12_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc13_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000434UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc13_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc13_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000435UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc13_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc13_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000436UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc13_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc13_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000437UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc13_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc14_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000438UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc14_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc14_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000439UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc14_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc14_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc14_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc14_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc14_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc15_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc15_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc15_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc15_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc15_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc15_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc15_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000043FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc15_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc16_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000440UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc16_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc16_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000441UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc16_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc16_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000442UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc16_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc16_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000443UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc16_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc17_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000444UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc17_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc17_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000445UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc17_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc17_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000446UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc17_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc17_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000447UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc17_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc18_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000448UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc18_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc18_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000449UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc18_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc18_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc18_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc18_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc18_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc19_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc19_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc19_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc19_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc19_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc19_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc19_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000044FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc19_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc20_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000450UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc20_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc20_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000451UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc20_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc20_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000452UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc20_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc20_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000453UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc20_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc21_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000454UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc21_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc21_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000455UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc21_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc21_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000456UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc21_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc21_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000457UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc21_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc22_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000458UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc22_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc22_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000459UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc22_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc22_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc22_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc22_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc22_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc23_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc23_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc23_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc23_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc23_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc23_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc23_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000045FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc23_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc24_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000460UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc24_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc24_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000461UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc24_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc24_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000462UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc24_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc24_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000463UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc24_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc25_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000464UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc25_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc25_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000465UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc25_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc25_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000466UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc25_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc25_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000467UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc25_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc26_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000468UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc26_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc26_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000469UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc26_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc26_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc26_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc26_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc26_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc27_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc27_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc27_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc27_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc27_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc27_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc27_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000046FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc27_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc28_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000470UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc28_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc28_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000471UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc28_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc28_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000472UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc28_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc28_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000473UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_mc28_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_basic")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_basic::dump();
+}
+
+TEST_CASE("ia32_vmx_basic_revision_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::revision_id::get() == 0x000000007FFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_basic_vmxon_vmcs_region_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::vmxon_vmcs_region_size::get() == 0x0000000000001FFFULL);
+}
+
+TEST_CASE("ia32_vmx_basic_physical_address_width")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0x0001000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::physical_address_width::get());
+
+    g_msrs[0x00000480UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_basic::physical_address_width::get());
+}
+
+TEST_CASE("ia32_vmx_basic_dual_monitor_mode_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0x0002000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::dual_monitor_mode_support::get());
+
+    g_msrs[0x00000480UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_basic::dual_monitor_mode_support::get());
+}
+
+TEST_CASE("ia32_vmx_basic_memory_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::memory_type::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_vmx_basic_ins_outs_exit_information")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0x0040000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::ins_outs_exit_information::get());
+
+    g_msrs[0x00000480UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_basic::ins_outs_exit_information::get());
+}
+
+TEST_CASE("ia32_vmx_basic_true_based_controls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000480UL] = 0x0080000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_basic::true_based_controls::get());
+
+    g_msrs[0x00000480UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_basic::true_based_controls::get());
+}
+
+TEST_CASE("ia32_vmx_pinbased_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000481UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_pinbased_ctls::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_pinbased_ctls_allowed_0_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000481UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_pinbased_ctls::allowed_0_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_pinbased_ctls_allowed_1_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000481UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_pinbased_ctls::allowed_1_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000482UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls_allowed_0_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000482UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls::allowed_0_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls_allowed_1_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000482UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls::allowed_1_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_exit_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000483UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_exit_ctls::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_exit_ctls_allowed_0_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000483UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_exit_ctls::allowed_0_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_exit_ctls_allowed_1_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000483UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_exit_ctls::allowed_1_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_entry_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000484UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_entry_ctls::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_entry_ctls_allowed_0_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000484UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_entry_ctls::allowed_0_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_entry_ctls_allowed_1_settings")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000484UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_entry_ctls::allowed_1_settings::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_misc::dump();
+}
+
+TEST_CASE("ia32_vmx_misc_preemption_timer_decrement")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::preemption_timer_decrement::get() == 0x000000000000001FULL);
+}
+
+TEST_CASE("ia32_vmx_misc_store_efer_lma_on_vm_exit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000000020ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::store_efer_lma_on_vm_exit::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::store_efer_lma_on_vm_exit::get());
+}
+
+TEST_CASE("ia32_vmx_misc_activity_state_hlt_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000000040ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::activity_state_hlt_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::activity_state_hlt_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_activity_state_shutdown_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000000080ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::activity_state_shutdown_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::activity_state_shutdown_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_activity_state_wait_for_sipi_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000000100ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::activity_state_wait_for_sipi_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::activity_state_wait_for_sipi_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_processor_trace_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000004000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::processor_trace_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::processor_trace_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_rdmsr_in_smm_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000000008000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::rdmsr_in_smm_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::rdmsr_in_smm_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_cr3_targets")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::cr3_targets::get() == 0x00000000000001FFULL);
+}
+
+TEST_CASE("ia32_vmx_misc_max_num_msr_load_store_on_exit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::max_num_msr_load_store_on_exit::get() == 0x0000000000000007ULL);
+}
+
+TEST_CASE("ia32_vmx_misc_vmxoff_blocked_smi_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000010000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::vmxoff_blocked_smi_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::vmxoff_blocked_smi_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_vmwrite_all_fields_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000020000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::vmwrite_all_fields_support::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::vmwrite_all_fields_support::get());
+}
+
+TEST_CASE("ia32_vmx_misc_injection_with_instruction_length_of_zero")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000485UL] = 0x0000000040000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get());
+
+    g_msrs[0x00000485UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get());
+}
+
+TEST_CASE("ia32_vmx_cr0_fixed0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000486UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_cr0_fixed0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_cr0_fixed1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000487UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_cr0_fixed1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_cr4_fixed0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000488UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_cr4_fixed0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_cr4_fixed1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000489UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_cr4_fixed1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_vmcs_enum")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_vmcs_enum::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_vmx_vmcs_enum_highest_index")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_vmcs_enum::highest_index::get() == 0x00000000000001FFULL);
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::get() == 0x00000000FFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_procbased_ctls2::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::get() == 0x0UL);
+
+    intel_x64::msrs::ia32_vmx_procbased_ctls2::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::allowed0() == 0xFFFFFFFFUL);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::allowed1() == 0x00000000UL);
+
+    intel_x64::msrs::ia32_vmx_procbased_ctls2::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = 0xFFFFFFFF00000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::allowed0() == 0x00000000UL);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::allowed1() == 0xFFFFFFFFUL);
+
+    intel_x64::msrs::ia32_vmx_procbased_ctls2::dump();
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_virtualize_apic_accesses")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_apic_accesses::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_ept")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_ept::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_descriptor_table_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::descriptor_table_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_rdtscp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_rdtscp::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_virtualize_x2apic_mode")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtualize_x2apic_mode::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_vpid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_wbinvd_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::wbinvd_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_unrestricted_guest")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::unrestricted_guest::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_apic_register_virtualization")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::apic_register_virtualization::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_virtual_interrupt_delivery")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::virtual_interrupt_delivery::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_pause_loop_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::pause_loop_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_rdrand_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdrand_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_invpcid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_invpcid::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_vm_functions")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_vm_functions::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_vmcs_shadowing")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::vmcs_shadowing::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_rdseed_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::rdseed_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_pml")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_pml::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_ept_violation_ve")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_procbased_ctls2_enable_xsaves_xrstors")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_procbased_ctls2::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_procbased_ctls2::enable_xsaves_xrstors::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_ept_vpid_cap::dump();
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_execute_only_translation")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::execute_only_translation::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::execute_only_translation::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_page_walk_length_of_4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000000040ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::page_walk_length_of_4::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::page_walk_length_of_4::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_memory_type_uncacheable_supported")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000000100ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_memory_type_write_back_supported")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000004000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_pde_2mb_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000010000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::pde_2mb_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::pde_2mb_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_pdpte_1gb_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000020000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::pdpte_1gb_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::pdpte_1gb_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invept_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000100000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_accessed_dirty_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000000200000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::accessed_dirty_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::accessed_dirty_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invept_single_context_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000002000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_single_context_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_single_context_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invept_all_context_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000004000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_all_context_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invept_all_context_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invvpid_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000000100000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invvpid_individual_address_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000010000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_individual_address_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_individual_address_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invvpid_single_context_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000020000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invvpid_all_context_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000040000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_all_context_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_all_context_support::get());
+}
+
+TEST_CASE("ia32_vmx_ept_vpid_cap_invvpid_single_context_retaining_globals_support")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000048CUL] = 0x0000080000000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_retaining_globals_support::get());
+
+    g_msrs[0x0000048CUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_ept_vpid_cap::invvpid_single_context_retaining_globals_support::get());
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::get() == 0x00000000FFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_true_pinbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::get() == 0x0UL);
+
+    intel_x64::msrs::ia32_vmx_true_pinbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::allowed0() == 0xFFFFFFFFUL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::allowed1() == 0x00000000UL);
+
+    intel_x64::msrs::ia32_vmx_true_pinbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = 0xFFFFFFFF00000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::allowed0() == 0x00000000UL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::allowed1() == 0xFFFFFFFFUL);
+
+    intel_x64::msrs::ia32_vmx_true_pinbased_ctls::dump();
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls_external_interrupt_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::external_interrupt_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls_nmi_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::nmi_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls_virtual_nmis")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::virtual_nmis::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls_activate_vmx_preemption_timer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::activate_vmx_preemption_timer::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_pinbased_ctls_process_posted_interrupts")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::get() == 0x00000000FFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_true_procbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::get() == 0x0UL);
+
+    intel_x64::msrs::ia32_vmx_true_procbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::allowed0() == 0xFFFFFFFFUL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::allowed1() == 0x00000000UL);
+
+    intel_x64::msrs::ia32_vmx_true_procbased_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = 0xFFFFFFFF00000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::allowed0() == 0x00000000UL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::allowed1() == 0xFFFFFFFFUL);
+
+    intel_x64::msrs::ia32_vmx_true_procbased_ctls::dump();
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_interrupt_window_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::interrupt_window_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_use_tsc_offsetting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tsc_offsetting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_hlt_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::hlt_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_invlpg_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::invlpg_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_mwait_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mwait_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_rdpmc_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdpmc_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_rdtsc_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::rdtsc_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_cr3_load_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_load_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_cr3_store_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr3_store_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_cr8_load_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_load_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_cr8_store_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::cr8_store_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_use_tpr_shadow")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_tpr_shadow::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_nmi_window_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::nmi_window_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_mov_dr_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::mov_dr_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_unconditional_io_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::unconditional_io_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_use_io_bitmaps")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_io_bitmaps::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_monitor_trap_flag")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_use_msr_bitmap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::use_msr_bitmap::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_monitor_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::monitor_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_pause_exiting")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::pause_exiting::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_procbased_ctls_activate_secondary_controls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::get() == 0x00000000FFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_true_exit_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::get() == 0x0UL);
+
+    intel_x64::msrs::ia32_vmx_true_exit_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::allowed0() == 0xFFFFFFFFUL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::allowed1() == 0x00000000UL);
+
+    intel_x64::msrs::ia32_vmx_true_exit_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = 0xFFFFFFFF00000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::allowed0() == 0x00000000UL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::allowed1() == 0xFFFFFFFFUL);
+
+    intel_x64::msrs::ia32_vmx_true_exit_ctls::dump();
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_save_debug_controls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_debug_controls::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_host_address_space_size")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::host_address_space_size::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_load_ia32_perf_global_ctrl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_perf_global_ctrl::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_acknowledge_interrupt_on_exit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::acknowledge_interrupt_on_exit::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_save_ia32_pat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_pat::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_load_ia32_pat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_pat::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_save_ia32_efer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_ia32_efer::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_load_ia32_efer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::load_ia32_efer::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_save_vmx_preemption_timer_value")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::save_vmx_preemption_timer_value::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_exit_ctls_clear_ia32_bndcfgs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_exit_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_exit_ctls::clear_ia32_bndcfgs::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::get() == 0x00000000FFFFFFFFULL);
+
+    intel_x64::msrs::ia32_vmx_true_entry_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::get() == 0x0UL);
+
+    intel_x64::msrs::ia32_vmx_true_entry_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = 0x00000000FFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::allowed0() == 0xFFFFFFFFUL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::allowed1() == 0x00000000UL);
+
+    intel_x64::msrs::ia32_vmx_true_entry_ctls::dump();
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = 0xFFFFFFFF00000000ULL;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::allowed0() == 0x00000000UL);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::allowed1() == 0xFFFFFFFFUL);
+
+    intel_x64::msrs::ia32_vmx_true_entry_ctls::dump();
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_load_debug_controls")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_debug_controls::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_ia_32e_mode_guest")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::ia_32e_mode_guest::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_entry_to_smm")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::entry_to_smm::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_deactivate_dual_monitor_treatment")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::deactivate_dual_monitor_treatment::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_load_ia32_perf_global_ctrl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_perf_global_ctrl::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_load_ia32_pat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_pat::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_load_ia32_efer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_efer::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_true_entry_ctls_load_ia32_bndcfgs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto mask = intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::mask;
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask;
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::get());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = mask | (mask << 32);
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed0());
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_true_entry_ctls::addr] = ~mask & ~(mask << 32);
+    CHECK(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed0());
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_true_entry_ctls::load_ia32_bndcfgs::is_allowed1());
+}
+
+TEST_CASE("ia32_vmx_vmfunc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_vmfunc::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_vmfunc::addr] = 0x0UL;
+    CHECK(intel_x64::msrs::ia32_vmx_vmfunc::get() == 0x0UL);
+}
+
+TEST_CASE("ia32_vmx_vmfunc_eptp_switching")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[intel_x64::msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_vmx_vmfunc::eptp_switching::is_allowed1());
+
+    g_msrs[intel_x64::msrs::ia32_vmx_vmfunc::addr] = 0xFFFFFFFFFFFFFFFEULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_vmx_vmfunc::eptp_switching::is_allowed1());
+}
+
+TEST_CASE("ia32_a_pmc0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc2::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc3::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc4::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc5::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc6::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_a_pmc7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_a_pmc7::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_a_pmc7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mcg_ext_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mcg_ext_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_mcg_ext_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mcg_ext_ctl_lmce_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_mcg_ext_ctl::lmce_en::set(true);
+    CHECK(intel_x64::msrs::ia32_mcg_ext_ctl::lmce_en::get());
+
+    intel_x64::msrs::ia32_mcg_ext_ctl::lmce_en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_mcg_ext_ctl::lmce_en::get());
+}
+
+TEST_CASE("ia32_sgx_svn_sinit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000500UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_sgx_svn_sinit::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sgx_svn_sinit_lock")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000500UL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_sgx_svn_sinit::lock::get());
+
+    g_msrs[0x00000500UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_sgx_svn_sinit::lock::get());
+}
+
+TEST_CASE("ia32_sgx_svn_sinit_sgx_svn_sinit")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000500UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_sgx_svn_sinit::sgx_svn_sinit::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_rtit_output_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_output_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_output_base::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_output_base_base_phys_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_output_base::base_phys_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_output_base::base_phys_address::get() == 0x00FFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_output_mask_ptrs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_output_mask_ptrs::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_output_mask_ptrs::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_output_mask_ptrs_mask_table_offset")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_output_mask_ptrs::mask_table_offset::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_output_mask_ptrs::mask_table_offset::get() == 0x0000000001FFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_output_mask_ptrs_output_offset")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_output_mask_ptrs::output_offset::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_output_mask_ptrs::output_offset::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_traceen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::traceen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::traceen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::traceen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::traceen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_cycen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::cycen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::cycen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::cycen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::cycen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_os")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::os::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::os::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::os::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::os::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_user")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::user::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::user::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::user::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::user::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_fabricen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::fabricen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::fabricen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::fabricen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::fabricen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_cr3_filter")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::cr3_filter::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::cr3_filter::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::cr3_filter::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::cr3_filter::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_topa")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::topa::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::topa::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::topa::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::topa::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_mtcen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::mtcen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::mtcen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::mtcen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::mtcen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_tscen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::tscen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::tscen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::tscen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::tscen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_disretc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::disretc::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::disretc::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::disretc::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::disretc::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_branchen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::branchen::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::branchen::get());
+
+    intel_x64::msrs::ia32_rtit_ctl::branchen::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_ctl::branchen::get());
+}
+
+TEST_CASE("ia32_rtit_ctl_mtcfreq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::mtcfreq::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::mtcfreq::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_cycthresh")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::cycthresh::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::cycthresh::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_psbfreq")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::psbfreq::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::psbfreq::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_addr0_cfg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::addr0_cfg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::addr0_cfg::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_addr1_cfg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::addr1_cfg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::addr1_cfg::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_addr2_cfg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::addr2_cfg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::addr2_cfg::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_ctl_addr3_cfg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_ctl::addr3_cfg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_ctl::addr3_cfg::get() == 0x000000000000000FULL);
+}
+
+TEST_CASE("ia32_rtit_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_status::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_status_filteren")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000571UL] = 0x0000000000000001ULL;
+    CHECK(intel_x64::msrs::ia32_rtit_status::filteren::get());
+
+    g_msrs[0x00000571UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_status::filteren::get());
+}
+
+TEST_CASE("ia32_rtit_status_contexen")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000571UL] = 0x0000000000000002ULL;
+    CHECK(intel_x64::msrs::ia32_rtit_status::contexen::get());
+
+    g_msrs[0x00000571UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_status::contexen::get());
+}
+
+TEST_CASE("ia32_rtit_status_triggeren")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000571UL] = 0x0000000000000004ULL;
+    CHECK(intel_x64::msrs::ia32_rtit_status::triggeren::get());
+
+    g_msrs[0x00000571UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_status::triggeren::get());
+}
+
+TEST_CASE("ia32_rtit_status_error")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_status::error::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_status::error::get());
+
+    intel_x64::msrs::ia32_rtit_status::error::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_status::error::get());
+}
+
+TEST_CASE("ia32_rtit_status_stopped")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_status::stopped::set(true);
+    CHECK(intel_x64::msrs::ia32_rtit_status::stopped::get());
+
+    intel_x64::msrs::ia32_rtit_status::stopped::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_rtit_status::stopped::get());
+}
+
+TEST_CASE("ia32_rtit_status_packetbytecnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_status::packetbytecnt::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_status::packetbytecnt::get() == 0x000000000001FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_cr3_match")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_cr3_match::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_cr3_match::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_cr3_match_cr3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_cr3_match::cr3::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_cr3_match::cr3::get() == 0x07FFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_a")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_a::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_a::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_a_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_a::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_a::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_a_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_a::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_a::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_b")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_b::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_b::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_b_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_b::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_b::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr0_b_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr0_b::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr0_b::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_a")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_a::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_a::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_a_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_a::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_a::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_a_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_a::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_a::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_b")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_b::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_b::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_b_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_b::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_b::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr1_b_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr1_b::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr1_b::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_a")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_a::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_a::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_a_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_a::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_a::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_a_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_a::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_a::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_b")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_b::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_b::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_b_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_b::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_b::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr2_b_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr2_b::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr2_b::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_a")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_a::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_a::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_a_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_a::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_a::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_a_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_a::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_a::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_b")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_b::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_b::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_b_virtual_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_b::virtual_address::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_b::virtual_address::get() == 0x0000FFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_rtit_addr3_b_signext_va")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_rtit_addr3_b::signext_va::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_rtit_addr3_b::signext_va::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_ds_area")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_ds_area::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_ds_area::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_tsc_deadline")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_tsc_deadline::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_tsc_deadline::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pm_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pm_enable::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pm_enable::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pm_enable_hwp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pm_enable::hwp::set(true);
+    CHECK(intel_x64::msrs::ia32_pm_enable::hwp::get());
+
+    intel_x64::msrs::ia32_pm_enable::hwp::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_pm_enable::hwp::get());
+}
+
+TEST_CASE("ia32_hwp_capabilities")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000771UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_hwp_capabilities::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_hwp_capabilities_highest_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000771UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_hwp_capabilities::highest_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_capabilities_guaranteed_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000771UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_hwp_capabilities::guaranteed_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_capabilities_most_efficient_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000771UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_hwp_capabilities::most_efficient_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_capabilities_lowest_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000771UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_hwp_capabilities::lowest_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg_min_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::min_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::min_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg_max_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::max_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::max_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg_desired_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::desired_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::desired_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg_energy_perf_pref")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::energy_perf_pref::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::energy_perf_pref::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_pkg_activity_window")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request_pkg::activity_window::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request_pkg::activity_window::get() == 0x00000000000003FFULL);
+}
+
+TEST_CASE("ia32_hwp_interrupt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_interrupt::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_interrupt::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_hwp_interrupt_perf_change")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_interrupt::perf_change::set(true);
+    CHECK(intel_x64::msrs::ia32_hwp_interrupt::perf_change::get());
+
+    intel_x64::msrs::ia32_hwp_interrupt::perf_change::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_hwp_interrupt::perf_change::get());
+}
+
+TEST_CASE("ia32_hwp_interrupt_excursion_min")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_interrupt::excursion_min::set(true);
+    CHECK(intel_x64::msrs::ia32_hwp_interrupt::excursion_min::get());
+
+    intel_x64::msrs::ia32_hwp_interrupt::excursion_min::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_hwp_interrupt::excursion_min::get());
+}
+
+TEST_CASE("ia32_hwp_request")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_hwp_request_min_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::min_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::min_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_max_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::max_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::max_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_desired_perf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::desired_perf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::desired_perf::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_energy_perf_pref")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::energy_perf_pref::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::energy_perf_pref::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_activity_window")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::activity_window::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_request::activity_window::get() == 0x00000000000003FFULL);
+}
+
+TEST_CASE("ia32_hwp_request_package_control")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_request::package_control::set(true);
+    CHECK(intel_x64::msrs::ia32_hwp_request::package_control::get());
+
+    intel_x64::msrs::ia32_hwp_request::package_control::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_hwp_request::package_control::get());
+}
+
+TEST_CASE("ia32_hwp_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_status::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_hwp_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_hwp_status_perf_change")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_status::perf_change::set(true);
+    CHECK(intel_x64::msrs::ia32_hwp_status::perf_change::get());
+
+    intel_x64::msrs::ia32_hwp_status::perf_change::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_hwp_status::perf_change::get());
+}
+
+TEST_CASE("ia32_hwp_status_excursion_to_min")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_hwp_status::excursion_to_min::set(true);
+    CHECK(intel_x64::msrs::ia32_hwp_status::excursion_to_min::get());
+
+    intel_x64::msrs::ia32_hwp_status::excursion_to_min::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_hwp_status::excursion_to_min::get());
+}
+
+TEST_CASE("ia32_x2apic_apicid")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000802UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_apicid::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_version")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000803UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_version::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tpr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_tpr::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_tpr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_ppr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000080AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_ppr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_eoi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_eoi::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(g_msrs[0x0000080BUL] == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_ldr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000080DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_ldr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_sivr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_sivr::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_sivr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000810UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000811UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000812UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000813UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000814UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000815UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000816UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_isr7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000817UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_isr7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000818UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000819UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_tmr7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000081FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_tmr7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000820UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000821UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000822UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr2::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000823UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr3::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000824UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr4::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000825UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr5::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000826UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr6::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_irr7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000827UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_irr7::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_esr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_esr::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_esr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_cmci")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_cmci::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_cmci::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_icr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_icr::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_icr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_timer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_timer::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_timer::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_thermal")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_thermal::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_thermal::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_pmi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_pmi::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_pmi::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_lint0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_lint0::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_lint0::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_lint1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_lint1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_lint1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_lvt_error")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_lvt_error::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_lvt_error::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_init_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_init_count::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_init_count::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_cur_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000839UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_x2apic_cur_count::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_div_conf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_div_conf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_x2apic_div_conf::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_x2apic_self_ipi")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_x2apic_self_ipi::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(g_msrs[0x0000083FUL] == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_debug_interface")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debug_interface::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_debug_interface::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_debug_interface_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debug_interface::enable::set(true);
+    CHECK(intel_x64::msrs::ia32_debug_interface::enable::get());
+
+    intel_x64::msrs::ia32_debug_interface::enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debug_interface::enable::get());
+}
+
+TEST_CASE("ia32_debug_interface_lock")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debug_interface::lock::set(true);
+    CHECK(intel_x64::msrs::ia32_debug_interface::lock::get());
+
+    intel_x64::msrs::ia32_debug_interface::lock::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debug_interface::lock::get());
+}
+
+TEST_CASE("ia32_debug_interface_debug_occurred")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_debug_interface::debug_occurred::set(true);
+    CHECK(intel_x64::msrs::ia32_debug_interface::debug_occurred::get());
+
+    intel_x64::msrs::ia32_debug_interface::debug_occurred::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_debug_interface::debug_occurred::get());
+}
+
+TEST_CASE("ia32_l3_qos_cfg")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_l3_qos_cfg::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_l3_qos_cfg::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_l3_qos_cfg_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_l3_qos_cfg::enable::set(true);
+    CHECK(intel_x64::msrs::ia32_l3_qos_cfg::enable::get());
+
+    intel_x64::msrs::ia32_l3_qos_cfg::enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_l3_qos_cfg::enable::get());
+}
+
+TEST_CASE("ia32_qm_evtsel")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_qm_evtsel::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_qm_evtsel::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_qm_evtsel_event_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_qm_evtsel::event_id::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_qm_evtsel::event_id::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_qm_evtsel_resource_monitoring_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_qm_evtsel::resource_monitoring_id::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_qm_evtsel::resource_monitoring_id::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_qm_ctr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000C8EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_qm_ctr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_qm_ctr_resource_monitored_data")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000C8EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_qm_ctr::resource_monitored_data::get() == 0x3FFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_qm_ctr_unavailable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000C8EUL] = 0x4000000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_qm_ctr::unavailable::get());
+
+    g_msrs[0x00000C8EUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_qm_ctr::unavailable::get());
+}
+
+TEST_CASE("ia32_qm_ctr_error")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000C8EUL] = 0x8000000000000000ULL;
+    CHECK(intel_x64::msrs::ia32_qm_ctr::error::get());
+
+    g_msrs[0x00000C8EUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(intel_x64::msrs::ia32_qm_ctr::error::get());
+}
+
+TEST_CASE("ia32_pqr_assoc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pqr_assoc::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pqr_assoc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pqr_assoc_resource_monitoring_id")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pqr_assoc::resource_monitoring_id::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pqr_assoc::resource_monitoring_id::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pqr_assoc_cos")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pqr_assoc::cos::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pqr_assoc::cos::get() == 0x00000000FFFFFFFFULL);
+}
+
+TEST_CASE("ia32_bndcfgs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bndcfgs::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_bndcfgs::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_bndcfgs_en")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bndcfgs::en::set(true);
+    CHECK(intel_x64::msrs::ia32_bndcfgs::en::get());
+
+    intel_x64::msrs::ia32_bndcfgs::en::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_bndcfgs::en::get());
+}
+
+TEST_CASE("ia32_bndcfgs_bndpreserve")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bndcfgs::bndpreserve::set(true);
+    CHECK(intel_x64::msrs::ia32_bndcfgs::bndpreserve::get());
+
+    intel_x64::msrs::ia32_bndcfgs::bndpreserve::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_bndcfgs::bndpreserve::get());
+}
+
+TEST_CASE("ia32_bndcfgs_base_address")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_bndcfgs::base_address::set(true);
+    CHECK(intel_x64::msrs::ia32_bndcfgs::base_address::get());
+
+    intel_x64::msrs::ia32_bndcfgs::base_address::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_bndcfgs::base_address::get());
+}
+
+TEST_CASE("ia32_xss")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_xss::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_xss::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_xss_trace_packet")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_xss::trace_packet::set(true);
+    CHECK(intel_x64::msrs::ia32_xss::trace_packet::get());
+
+    intel_x64::msrs::ia32_xss::trace_packet::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_xss::trace_packet::get());
+}
+
+TEST_CASE("ia32_pkg_hdc_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pkg_hdc_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pkg_hdc_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pkg_hdc_ctl_hdc_pkg_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pkg_hdc_ctl::hdc_pkg_enable::set(true);
+    CHECK(intel_x64::msrs::ia32_pkg_hdc_ctl::hdc_pkg_enable::get());
+
+    intel_x64::msrs::ia32_pkg_hdc_ctl::hdc_pkg_enable::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_pkg_hdc_ctl::hdc_pkg_enable::get());
+}
+
+TEST_CASE("ia32_pm_ctl1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pm_ctl1::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_pm_ctl1::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pm_ctl1_hdc_allow_block")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_pm_ctl1::hdc_allow_block::set(true);
+    CHECK(intel_x64::msrs::ia32_pm_ctl1::hdc_allow_block::get());
+
+    intel_x64::msrs::ia32_pm_ctl1::hdc_allow_block::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_pm_ctl1::hdc_allow_block::get());
+}
+
+TEST_CASE("ia32_thread_stall")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000DB2UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(intel_x64::msrs::ia32_thread_stall::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_thread_stall_stall_cycle_cnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_thread_stall::stall_cycle_cnt::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_thread_stall::stall_cycle_cnt::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_efer")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_efer::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    intel_x64::msrs::ia32_efer::dump();
+}
+
+TEST_CASE("ia32_efer_sce")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::sce::set(true);
+    CHECK(intel_x64::msrs::ia32_efer::sce::get());
+
+    intel_x64::msrs::ia32_efer::sce::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_efer::sce::get());
+}
+
+TEST_CASE("ia32_efer_lme")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::lme::set(true);
+    CHECK(intel_x64::msrs::ia32_efer::lme::get());
+
+    intel_x64::msrs::ia32_efer::lme::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_efer::lme::get());
+}
+
+TEST_CASE("ia32_efer_lma")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::lma::set(true);
+    CHECK(intel_x64::msrs::ia32_efer::lma::get());
+
+    intel_x64::msrs::ia32_efer::lma::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_efer::lma::get());
+}
+
+TEST_CASE("ia32_efer_nxe")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::nxe::set(true);
+    CHECK(intel_x64::msrs::ia32_efer::nxe::get());
+
+    intel_x64::msrs::ia32_efer::nxe::set(false);
+    CHECK_FALSE(intel_x64::msrs::ia32_efer::nxe::get());
+}
+
+TEST_CASE("ia32_efer_reserved")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_efer::reserved::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_efer::reserved::get() == 0xFFFFFFFFFFFFF2FEULL);
+}
+
+TEST_CASE("ia32_fs_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_fs_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_fs_base::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_gs_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    intel_x64::msrs::ia32_gs_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(intel_x64::msrs::ia32_gs_base::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+#endif

--- a/src/intrinsics/tests/test_msrs_x64.cpp
+++ b/src/intrinsics/tests/test_msrs_x64.cpp
@@ -19,167 +19,853 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#define CATCH_CONFIG_MAIN
 #include <catch/catch.hpp>
+#include <intrinsics/x86/common_x64.h>
+#include <hippomocks.h>
 
-TEST_CASE("test name goes here")
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+using namespace x64;
+
+std::map<msrs::field_type, msrs::value_type> g_msrs;
+
+extern "C" uint64_t
+test_read_msr(uint32_t addr) noexcept
+{ return g_msrs[addr]; }
+
+extern "C" void
+test_write_msr(uint32_t addr, uint64_t val) noexcept
+{ g_msrs[addr] = val; }
+
+static void
+setup_intrinsics(MockRepository &mocks)
 {
-    CHECK(true);
+    mocks.OnCallFunc(_read_msr).Do(test_read_msr);
+    mocks.OnCallFunc(_write_msr).Do(test_write_msr);
 }
 
-// #include <test.h>
-// #include <intrinsics/msrs_x64.h>
+TEST_CASE("ia32_p5_mc_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// using namespace x64;
+    g_msrs[0x00000000UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_p5_mc_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-// std::map<msrs::field_type, msrs::value_type> g_msrs;
+TEST_CASE("ia32_p5_mc_type")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// extern "C" uint64_t
-// __read_msr(uint32_t addr) noexcept
-// { return g_msrs[addr]; }
+    g_msrs[0x00000001UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_p5_mc_type::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-// extern "C" void
-// __write_msr(uint32_t addr, uint64_t val) noexcept
-// { g_msrs[addr] = val; }
+TEST_CASE("ia32_tsc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat()
-// {
-//     msrs::ia32_pat::set(0xFFFFFFFFFFFFFFFFUL);
-//     this->expect_true(msrs::ia32_pat::get() == 0xFFFFFFFFFFFFFFFFUL);
+    g_msrs[0x00000010UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_tsc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-//     msrs::ia32_pat::dump();
+TEST_CASE("ia32_apic_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-//     msrs::ia32_pat::set(0x0U);
-//     this->expect_true(msrs::ia32_pat::get() == 0x0U);
-// }
+    msrs::ia32_apic_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_apic_base::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-// void
-// intrinsics_ut::test_ia32_pat_pa0()
-// {
-//     msrs::ia32_pat::pa0::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa0::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa0::get(0x0000000000000006UL) == 6UL);
+TEST_CASE("ia32_apic_base_bsp_flag")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-//     msrs::ia32_pat::pa0::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa0::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa0::get(0x0000000000000004UL) == 4UL);
-// }
+    msrs::ia32_apic_base::bsp_flag::set(true);
+    CHECK(msrs::ia32_apic_base::bsp_flag::get());
 
-// void
-// intrinsics_ut::test_ia32_pat_pa1()
-// {
-//     msrs::ia32_pat::pa1::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa1::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa1::get(0x0000000000000600UL) == 6UL);
+    msrs::ia32_apic_base::bsp_flag::set(false);
+    CHECK_FALSE(msrs::ia32_apic_base::bsp_flag::get());
+}
 
-//     msrs::ia32_pat::pa1::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa1::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa1::get(0x0000000000000400UL) == 4UL);
-// }
+TEST_CASE("ia32_apic_base_enable_x2apic")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat_pa2()
-// {
-//     msrs::ia32_pat::pa2::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa2::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa2::get(0x0000000000060000UL) == 6UL);
+    msrs::ia32_apic_base::enable_x2apic::set(true);
+    CHECK(msrs::ia32_apic_base::enable_x2apic::get());
 
-//     msrs::ia32_pat::pa2::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa2::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa2::get(0x0000000000040000UL) == 4UL);
-// }
+    msrs::ia32_apic_base::enable_x2apic::set(false);
+    CHECK_FALSE(msrs::ia32_apic_base::enable_x2apic::get());
+}
 
-// void
-// intrinsics_ut::test_ia32_pat_pa3()
-// {
-//     msrs::ia32_pat::pa3::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa3::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa3::get(0x0000000006000000UL) == 6UL);
+TEST_CASE("ia32_apic_base_apic_global_enable")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-//     msrs::ia32_pat::pa3::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa3::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa3::get(0x0000000004000000UL) == 4UL);
-// }
+    msrs::ia32_apic_base::apic_global_enable::set(true);
+    CHECK(msrs::ia32_apic_base::apic_global_enable::get());
 
-// void
-// intrinsics_ut::test_ia32_pat_pa4()
-// {
-//     msrs::ia32_pat::pa4::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa4::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa4::get(0x0000000600000000UL) == 6UL);
+    msrs::ia32_apic_base::apic_global_enable::set(false);
+    CHECK_FALSE(msrs::ia32_apic_base::apic_global_enable::get());
+}
 
-//     msrs::ia32_pat::pa4::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa4::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa4::get(0x0000000400000000UL) == 4UL);
-// }
+TEST_CASE("ia32_apic_base_apic_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat_pa5()
-// {
-//     msrs::ia32_pat::pa5::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa5::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa5::get(0x0000060000000000UL) == 6UL);
+    msrs::ia32_apic_base::apic_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_apic_base::apic_base::get() == 0x000FFFFFFFFFFFFFULL);
+}
 
-//     msrs::ia32_pat::pa5::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa5::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa5::get(0x0000040000000000UL) == 4UL);
-// }
+TEST_CASE("ia32_mperf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat_pa6()
-// {
-//     msrs::ia32_pat::pa6::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa6::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa6::get(0x0006000000000000UL) == 6UL);
+    msrs::ia32_mperf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_mperf::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-//     msrs::ia32_pat::pa6::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa6::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa6::get(0x0004000000000000UL) == 4UL);
-// }
+TEST_CASE("ia32_mperf_tsc_freq_clock_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat_pa7()
-// {
-//     msrs::ia32_pat::pa7::set(6UL);
-//     this->expect_true(msrs::ia32_pat::pa7::get() == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa7::get(0x0600000000000000UL) == 6UL);
+    msrs::ia32_mperf::tsc_freq_clock_count::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_mperf::tsc_freq_clock_count::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-//     msrs::ia32_pat::pa7::set(4UL);
-//     this->expect_true(msrs::ia32_pat::pa7::get() == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa7::get(0x0400000000000000UL) == 4UL);
-// }
+TEST_CASE("ia32_aperf")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-// void
-// intrinsics_ut::test_ia32_pat_pa()
-// {
-//     msrs::ia32_pat::pa0::set(0UL);
-//     msrs::ia32_pat::pa1::set(1UL);
-//     msrs::ia32_pat::pa2::set(2UL);
-//     msrs::ia32_pat::pa3::set(3UL);
-//     msrs::ia32_pat::pa4::set(4UL);
-//     msrs::ia32_pat::pa5::set(5UL);
-//     msrs::ia32_pat::pa6::set(6UL);
-//     msrs::ia32_pat::pa7::set(7UL);
+    msrs::ia32_aperf::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_aperf::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-//     this->expect_true(msrs::ia32_pat::pa(0UL) == 0UL);
-//     this->expect_true(msrs::ia32_pat::pa(1UL) == 1UL);
-//     this->expect_true(msrs::ia32_pat::pa(2UL) == 2UL);
-//     this->expect_true(msrs::ia32_pat::pa(3UL) == 3UL);
-//     this->expect_true(msrs::ia32_pat::pa(4UL) == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa(5UL) == 5UL);
-//     this->expect_true(msrs::ia32_pat::pa(6UL) == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa(7UL) == 7UL);
+TEST_CASE("ia32_aperf_actual_freq_clock_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
 
-//     this->expect_true(msrs::ia32_pat::pa(0x0000000000000000UL, 0UL) == 0UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0000000000000100UL, 1UL) == 1UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0000000000020000UL, 2UL) == 2UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0000000003000000UL, 3UL) == 3UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0000000400000000UL, 4UL) == 4UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0000050000000000UL, 5UL) == 5UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0006000000000000UL, 6UL) == 6UL);
-//     this->expect_true(msrs::ia32_pat::pa(0x0700000000000000UL, 7UL) == 7UL);
+    msrs::ia32_aperf::actual_freq_clock_count::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_aperf::actual_freq_clock_count::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
 
-//     this->expect_exception([&] { msrs::ia32_pat::pa(10UL); }, ""_ut_ree);
-//     this->expect_exception([&] { msrs::ia32_pat::pa(0x0000000000000000UL, 10UL); }, ""_ut_ree);
-// }
+TEST_CASE("ia32_mtrrcap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000000FEUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mtrrcap::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mtrrcap_vcnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000000FEUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mtrrcap::vcnt::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_mtrrcap_fixed_range_mtrr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000000FEUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mtrrcap::fixed_range_mtrr::get());
+
+    g_msrs[0x000000FEUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mtrrcap::fixed_range_mtrr::get());
+}
+
+TEST_CASE("ia32_mtrrcap_wc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000000FEUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mtrrcap::wc::get());
+
+    g_msrs[0x000000FEUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mtrrcap::wc::get());
+}
+
+TEST_CASE("ia32_mtrrcap_smrr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x000000FEUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mtrrcap::smrr::get());
+
+    g_msrs[0x000000FEUL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mtrrcap::smrr::get());
+}
+
+TEST_CASE("ia32_sysenter_cs")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_sysenter_cs::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_sysenter_cs::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_cs_cs_selector")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_sysenter_cs::cs_selector::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_sysenter_cs::cs_selector::get() == 0x000000000000FFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_esp")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_sysenter_esp::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_sysenter_esp::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_sysenter_eip")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_sysenter_eip::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_sysenter_eip::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mcg_cap")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mcg_cap_count")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::count::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_ctl::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_ctl::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_ext")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_ext::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_ext::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_cmci")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_cmci::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_cmci::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_tes")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_tes::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_tes::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_ext_cnt")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_ext_cnt::get() == 0x00000000000000FFULL);
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_ser")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_ser::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_ser::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_elog")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_elog::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_elog::get());
+}
+
+TEST_CASE("ia32_mcg_cap_mcg_lmce")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000179UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mcg_cap::mcg_lmce::get());
+
+    g_msrs[0x00000179UL] = 0x0000000000000000ULL;
+    CHECK_FALSE(msrs::ia32_mcg_cap::mcg_lmce::get());
+}
+
+TEST_CASE("ia32_mcg_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_status::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_mcg_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mcg_status_ripv")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_status::ripv::set(true);
+    CHECK(msrs::ia32_mcg_status::ripv::get());
+
+    msrs::ia32_mcg_status::ripv::set(false);
+    CHECK_FALSE(msrs::ia32_mcg_status::ripv::get());
+}
+
+TEST_CASE("ia32_mcg_status_eipv")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_status::eipv::set(true);
+    CHECK(msrs::ia32_mcg_status::eipv::get());
+
+    msrs::ia32_mcg_status::eipv::set(false);
+    CHECK_FALSE(msrs::ia32_mcg_status::eipv::get());
+}
+
+TEST_CASE("ia32_mcg_status_mcip")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_status::mcip::set(true);
+    CHECK(msrs::ia32_mcg_status::mcip::get());
+
+    msrs::ia32_mcg_status::mcip::set(false);
+    CHECK_FALSE(msrs::ia32_mcg_status::mcip::get());
+}
+
+TEST_CASE("ia32_mcg_status_lmce_s")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_status::lmce_s::set(true);
+    CHECK(msrs::ia32_mcg_status::lmce_s::get());
+
+    msrs::ia32_mcg_status::lmce_s::set(false);
+    CHECK_FALSE(msrs::ia32_mcg_status::lmce_s::get());
+}
+
+TEST_CASE("ia32_mcg_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_mcg_ctl::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_mcg_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_pat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_pat::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("test_ia32_pat")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_pat::get() == 0xFFFFFFFFFFFFFFFFULL);
+
+    msrs::ia32_pat::dump();
+
+    msrs::ia32_pat::set(0x0UL);
+    CHECK(msrs::ia32_pat::get() == 0x0UL);
+}
+
+TEST_CASE("test_ia32_pat_pa0")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa0::set(6UL);
+    CHECK(msrs::ia32_pat::pa0::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa0::get(0x0000000000000006ULL) == 6UL);
+
+    msrs::ia32_pat::pa0::set(4UL);
+    CHECK(msrs::ia32_pat::pa0::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa0::get(0x0000000000000004ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa1")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa1::set(6UL);
+    CHECK(msrs::ia32_pat::pa1::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa1::get(0x0000000000000600ULL) == 6UL);
+
+    msrs::ia32_pat::pa1::set(4UL);
+    CHECK(msrs::ia32_pat::pa1::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa1::get(0x0000000000000400ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa2")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa2::set(6UL);
+    CHECK(msrs::ia32_pat::pa2::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa2::get(0x0000000000060000ULL) == 6UL);
+
+    msrs::ia32_pat::pa2::set(4UL);
+    CHECK(msrs::ia32_pat::pa2::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa2::get(0x0000000000040000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa3")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa3::set(6UL);
+    CHECK(msrs::ia32_pat::pa3::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa3::get(0x0000000006000000ULL) == 6UL);
+
+    msrs::ia32_pat::pa3::set(4UL);
+    CHECK(msrs::ia32_pat::pa3::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa3::get(0x0000000004000000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa4")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa4::set(6UL);
+    CHECK(msrs::ia32_pat::pa4::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa4::get(0x0000000600000000ULL) == 6UL);
+
+    msrs::ia32_pat::pa4::set(4UL);
+    CHECK(msrs::ia32_pat::pa4::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa4::get(0x0000000400000000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa5")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa5::set(6UL);
+    CHECK(msrs::ia32_pat::pa5::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa5::get(0x0000060000000000ULL) == 6UL);
+
+    msrs::ia32_pat::pa5::set(4UL);
+    CHECK(msrs::ia32_pat::pa5::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa5::get(0x0000040000000000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa6")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa6::set(6UL);
+    CHECK(msrs::ia32_pat::pa6::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa6::get(0x0006000000000000ULL) == 6UL);
+
+    msrs::ia32_pat::pa6::set(4UL);
+    CHECK(msrs::ia32_pat::pa6::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa6::get(0x0004000000000000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa7")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa7::set(6UL);
+    CHECK(msrs::ia32_pat::pa7::get() == 6UL);
+    CHECK(msrs::ia32_pat::pa7::get(0x0600000000000000ULL) == 6UL);
+
+    msrs::ia32_pat::pa7::set(4UL);
+    CHECK(msrs::ia32_pat::pa7::get() == 4UL);
+    CHECK(msrs::ia32_pat::pa7::get(0x0400000000000000ULL) == 4UL);
+}
+
+TEST_CASE("test_ia32_pat_pa")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_pat::pa0::set(0UL);
+    msrs::ia32_pat::pa1::set(1UL);
+    msrs::ia32_pat::pa2::set(2UL);
+    msrs::ia32_pat::pa3::set(3UL);
+    msrs::ia32_pat::pa4::set(4UL);
+    msrs::ia32_pat::pa5::set(5UL);
+    msrs::ia32_pat::pa6::set(6UL);
+    msrs::ia32_pat::pa7::set(7UL);
+
+    CHECK(msrs::ia32_pat::pa(0UL) == 0UL);
+    CHECK(msrs::ia32_pat::pa(1UL) == 1UL);
+    CHECK(msrs::ia32_pat::pa(2UL) == 2UL);
+    CHECK(msrs::ia32_pat::pa(3UL) == 3UL);
+    CHECK(msrs::ia32_pat::pa(4UL) == 4UL);
+    CHECK(msrs::ia32_pat::pa(5UL) == 5UL);
+    CHECK(msrs::ia32_pat::pa(6UL) == 6UL);
+    CHECK(msrs::ia32_pat::pa(7UL) == 7UL);
+    CHECK_THROWS(msrs::ia32_pat::pa(8UL));
+
+    CHECK(msrs::ia32_pat::pa(0x0000000000000000ULL, 0UL) == 0UL);
+    CHECK(msrs::ia32_pat::pa(0x0000000000000100ULL, 1UL) == 1UL);
+    CHECK(msrs::ia32_pat::pa(0x0000000000020000ULL, 2UL) == 2UL);
+    CHECK(msrs::ia32_pat::pa(0x0000000003000000ULL, 3UL) == 3UL);
+    CHECK(msrs::ia32_pat::pa(0x0000000400000000ULL, 4UL) == 4UL);
+    CHECK(msrs::ia32_pat::pa(0x0000050000000000ULL, 5UL) == 5UL);
+    CHECK(msrs::ia32_pat::pa(0x0006000000000000ULL, 6UL) == 6UL);
+    CHECK(msrs::ia32_pat::pa(0x0700000000000000ULL, 7UL) == 7UL);
+    CHECK_THROWS(msrs::ia32_pat::pa(0x8000000000000000ULL, 8UL));
+}
+
+TEST_CASE("ia32_mc0_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000400UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc0_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc0_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000401UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc0_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc0_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000402UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc0_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc0_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000403UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc0_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc1_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000404UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc1_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc1_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000405UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc1_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc1_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000406UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc1_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc1_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000407UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc1_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc2_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000408UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc2_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc2_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000409UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc2_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc2_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040AUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc2_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc2_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040BUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc2_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc3_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040CUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc3_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc3_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040DUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc3_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc3_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040EUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc3_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc3_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x0000040FUL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc3_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc4_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000410UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc4_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc4_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000411UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc4_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc4_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000412UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc4_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc4_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000413UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc4_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc5_ctl")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000414UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc5_ctl::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc5_status")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000415UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc5_status::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc5_addr")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000416UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc5_addr::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_mc5_misc")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    g_msrs[0x00000417UL] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(msrs::ia32_mc5_misc::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_star")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_star::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_star::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_lstar")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_lstar::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_lstar::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_fmask")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_fmask::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_fmask::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_kernel_gs_base")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_kernel_gs_base::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_kernel_gs_base::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_tsc_aux")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_tsc_aux::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_tsc_aux::get() == 0xFFFFFFFFFFFFFFFFULL);
+}
+
+TEST_CASE("ia32_tsc_aux_aux")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    msrs::ia32_tsc_aux::aux::set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(msrs::ia32_tsc_aux::aux::get() == 0x00000000FFFFFFFFULL);
+}
+
+#endif


### PR DESCRIPTION
Added all MSR functions in Volume 4 Chapter 2.1 Table 2-2 in the Intel SDM. These functions were placed in `include/intrinsics/x86/common/msrs/msrs_x64.h` and `include/intrinsics/x86/intel/msrs/msrs_intel_x64.h`. Tests for these headers were created in `src/intrinsics/tests/test_msrs_x64.cpp` and `src/intrinsics/tests/test_msrs_intel_x64.cpp`. All addresses were explicitly casted in all `msrs::get()` calls in `include/intrinsics/x86/intel/vmcs/helpers.h`, `include/intrinsics/x86/intel/vmcs/64bit_control_fields.h`, `include/intrinsics/x86/intel/vmcs/check_controls.h`, and `src/exit_handler/src/exit_handler_intel_x64.cpp` to make all calls conform to the same template.